### PR TITLE
Moving .changes format to 1.8, fix documentation, added project.version variable

### DIFF
--- a/docs/maven.md
+++ b/docs/maven.md
@@ -103,9 +103,9 @@ following options:
     *---------------+------------------------------------------------------------------------------+---------------------------------------------+
     | type          | Type of the data source. (archive|directory|file)                            | No; but will be Yes in the future           |
     *---------------+------------------------------------------------------------------------------+---------------------------------------------+
-    | include       | A comma seperated list of files to include from the directory or tarball     | No; defaults to all files                   |
+    | includes      | A comma seperated list of files to include from the directory or tarball     | No; defaults to all files                   |
     *---------------+------------------------------------------------------------------------------+---------------------------------------------+
-    | exclude       | A comma seperated list of files to exclude from the directory or tarball     | No; defaults to no exclutions               |
+    | excludes      | A comma seperated list of files to exclude from the directory or tarball     | No; defaults to no exclutions               |
     *---------------+------------------------------------------------------------------------------+---------------------------------------------+
     | mapper        | The files to exclude from the directory or tarball                           | No                                          |
     *---------------+------------------------------------------------------------------------------+---------------------------------------------+
@@ -132,8 +132,8 @@ include a directory, a tarball, and a file in your deb package:
                                 <data>
                                     <src>${project.basedir}/target/my_archive.tar.gz</src>
                                     <type>archive</type>
-                                    <include>...</include>
-                                    <exclude>...</exclude>
+                                    <includes>...</includes>
+                                    <excludes>...</excludes>
                                     <mapper>
                                         <type>perm</type>
                                         <strip>1</strip>
@@ -148,8 +148,8 @@ include a directory, a tarball, and a file in your deb package:
                                 <data>
                                     <src>${project.build.directory}/data</src>
                                     <type>directory</type>
-                                    <include/>
-                                    <exclude>**/.svn</exclude>
+                                    <includes />
+                                    <excludes>**/.svn</excludes>
                                     <mapper>
                                         <type>ls</type>
                                         <src>mapping.txt</src>

--- a/src/main/java/org/vafer/jdeb/descriptors/ChangesDescriptor.java
+++ b/src/main/java/org/vafer/jdeb/descriptors/ChangesDescriptor.java
@@ -38,6 +38,8 @@ public final class ChangesDescriptor extends AbstractDescriptor {
         "Description",
         "Changes",
         "Closes",
+        "Checksums-Sha1",
+        "Checksums-Sha256",
         "Files"
     };
     
@@ -53,6 +55,8 @@ public final class ChangesDescriptor extends AbstractDescriptor {
         "Maintainer",
         "Description",
         "Changes",
+        "Checksums-Sha1",
+        "Checksums-Sha256",
         "Files"
     };
 

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -200,10 +200,12 @@ public class DebMojo extends AbstractPluginMojo {
         variables.put("artifactId", getProject().getArtifactId());
         variables.put("groupId", getProject().getGroupId());
         variables.put("version", getProject().getVersion().replace('-', '+'));
+
         variables.put("description", getProject().getDescription());
         variables.put("extension", "deb");
         variables.put("baseDir", getProject().getBasedir().getAbsolutePath());
         variables.put("buildDir", buildDirectory.getAbsolutePath());
+        variables.put("project.version", getProject().getVersion());
         return new MapVariableResolver(variables);
     }
 

--- a/src/main/java/org/vafer/jdeb/utils/InformationOutputStream.java
+++ b/src/main/java/org/vafer/jdeb/utils/InformationOutputStream.java
@@ -38,7 +38,7 @@ public class InformationOutputStream extends DigestOutputStream {
         size = 0;
     }
     
-    public String getMd5() {
+    public String getHexDigest() {
         return Utils.toHex(digest.digest());
     }
     


### PR DESCRIPTION
1. Moving .changes format to 1.8, added mandatory fields "Checksums-Sha1" and "Checksums-Sha2"
2. Fixed documentation in maven.md, replacing "include" to "includes", "exclude" to "excludes"
3. Added project.version into variables for control file, in order to get original project version without changing "-" to "+"
