### PR TITLE
Version related fix + generation deb packages in windows

### DIFF
--- a/src/main/java/org/vafer/jdeb/Processor.java
+++ b/src/main/java/org/vafer/jdeb/Processor.java
@@ -411,7 +411,7 @@ public class Processor {
             public void onEachFile( InputStream inputStream, String filename, String linkname, String user, int uid, String group, int gid, int mode, long size ) throws IOException {
                 filename = fixPath(filename);
 
-                createParentDirectories((new File(filename)).getParent(), user, uid, group, gid);
+                createParentDirectories(fixPath(new File(filename).getParent()), user, uid, group, gid);
 
                 TarEntry entry = new TarEntry(filename);
 
@@ -464,6 +464,8 @@ public class Processor {
                 } else if (!path.startsWith("./")) {
                     path = "./" + path;
                 }
+                //remove double slashes in order to get unique file/folder names
+                path=path.replaceAll("\\/\\/","\\/");
                 return path;
             }
             


### PR DESCRIPTION
Now user can build any version using version regex and version mask, fixed deb package generation in Windows Environment.
1. Added splitVersionRegexString param (default [-.]) with the regex project.version will break into three parts (maximum)  - version.major, version.minor, version.build
2. Added versionMask param (default [[version.major]].[[version.minor]]+[[version.build]]) will generate version by replacement of relevant parts
3. Added versionReplacementString param (default +) , with replace divider (splitVersionRegexString) in third part (e.g. in case you've version 1.3.4.5.6 output with defaults will provide: 1.3.4+5+6)
4. Fixed deb generation in windows environment
