### PR TITLE
Added an optional parameter to limit execution to the top-level of a pro...

### DIFF
--- a/docs/maven.md
+++ b/docs/maven.md
@@ -97,6 +97,8 @@ section with any of the following options:
     *---------------+------------------------------------------------------------------------------+------------------------------------------------------------------+
     | attach        | Attach artifact to project                                                   | No; defaults to 'true'                                           |
     *---------------+------------------------------------------------------------------------------+------------------------------------------------------------------+
+    | submodules    | Execute the goal on all sub-modules                                          | No; defaults to 'true'                   |
+    *---------------+------------------------------------------------------------------------------+------------------------------------------------------------------+
 
 If you use the 'dataSet' element, you'll need to populate it with a one or
 more 'data' elements. A 'data' element is used to specify a 'directory', a

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>2.1.0</version>
         </dependency>


### PR DESCRIPTION
Added an optional config param, 'ignoreSubModules', for use with aggregate mvn projects.  When set to true,  the jdeb goal will not be executed on sub-modules.  The purpose of this change is to add a feature that forces the jdeb goal only run once on an aggregate project. 
