### PR TITLE
fixed minor bug in Utils.stripPath() which caused stripping at most 1 directory from the path

### DIFF
--- a/src/main/java/org/vafer/jdeb/utils/Utils.java
+++ b/src/main/java/org/vafer/jdeb/utils/Utils.java
@@ -60,7 +60,7 @@ public final class Utils {
 
         int x = 0;
         for (int i=0 ; i<p; i++) {
-            x = s.indexOf('/', x);
+            x = s.indexOf('/', x+1);
             if (x < 0) {
                 return s;
             }

--- a/src/test/java/org/vafer/jdeb/utils/UtilsTestCase.java
+++ b/src/test/java/org/vafer/jdeb/utils/UtilsTestCase.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vafer.jdeb.utils;
+
+
+import junit.framework.TestCase;
+
+public class UtilsTestCase extends TestCase {
+
+    public void testStripPath() throws Exception {
+        assertEquals("foo/bar", Utils.stripPath(0,"foo/bar"));
+
+        assertEquals("bar", Utils.stripPath(1,"foo/bar"));
+
+        assertEquals("bar/baz", Utils.stripPath(1,"foo/bar/baz"));
+        assertEquals("baz", Utils.stripPath(2,"foo/bar/baz"));
+
+        assertEquals("foo/", Utils.stripPath(0,"foo/"));
+        assertEquals("", Utils.stripPath(1,"foo/"));
+        assertEquals("foo/", Utils.stripPath(2,"foo/"));
+    }
+}


### PR DESCRIPTION
String.indexOf() was called with the old index as starting index, which
caused the function to find the same "/" again on the next iteration
