### PR TITLE
Automatic creation of conffiles file.

### DIFF
--- a/docs/maven.md
+++ b/docs/maven.md
@@ -97,7 +97,10 @@ section with any of the following options:
     *---------------+------------------------------------------------------------------------------+------------------------------------------------------------------+
     | attach        | Attach artifact to project                                                   | No; defaults to 'true'                                           |
     *---------------+------------------------------------------------------------------------------+------------------------------------------------------------------+
-    | submodules    | Execute the goal on all sub-modules                                          | No; defaults to 'true'                   |
+    | submodules    | Execute the goal on all sub-modules                                          | No; defaults to 'true'                                           |
+    *---------------+------------------------------------------------------------------------------+------------------------------------------------------------------+
+    | confFiles     | FileSet specifying config files to be kept on package updates or removal.    | No                                                               |
+    |               | Ignored if a 'conffiles' file is present in the control directory.           |                                                                  | 
     *---------------+------------------------------------------------------------------------------+------------------------------------------------------------------+
 
 If you use the 'dataSet' element, you'll need to populate it with a one or
@@ -197,6 +200,15 @@ include a directory, a tarball, and a file in your deb package:
                                 </data>
                             </dataSet>
                             ...
+                            <confFiles>
+                                <fileSet>
+                                    <directory>${project.basedir}/src/main/config</directory>
+                                    <outputDirectory>/etc/my-project</outputDirectory>
+                                    <includes>
+                                        <include>*.conf</include>
+                                    </includes>
+                                 </fileSet>
+                            </confFiles>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,18 @@
             <version>3.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>file-management</artifactId>
+            <version>1.2.1</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>11.0.1</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
     <reporting>
         <excludeDefaults>true</excludeDefaults>

--- a/src/main/java/org/vafer/jdeb/Console.java
+++ b/src/main/java/org/vafer/jdeb/Console.java
@@ -23,5 +23,5 @@ package org.vafer.jdeb;
 public interface Console {
 
     void println( String s );
-
+    void warn(String message);
 }

--- a/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
+++ b/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
@@ -25,6 +25,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.taskdefs.MatchingTask;
 import org.apache.tools.ant.taskdefs.Tar;
 import org.apache.tools.ant.types.FileSet;
+import org.apache.tools.ant.types.LogLevel;
 import org.vafer.jdeb.Console;
 import org.vafer.jdeb.DataProducer;
 import org.vafer.jdeb.Processor;
@@ -189,6 +190,10 @@ public class DebAntTask extends MatchingTask {
                 if (verbose) {
                     log(s);
                 }
+            }
+
+            public void warn(String message) {
+                log(message, LogLevel.WARN.getLevel());
             }
         }, null);
 

--- a/src/main/java/org/vafer/jdeb/maven/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMaker.java
@@ -19,7 +19,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.vafer.jdeb.Console;
 import org.vafer.jdeb.DataProducer;
@@ -70,6 +72,9 @@ public class DebMaker {
     /** The file where to write the changes of the changes input to */
     private File changesSave;
 
+    /** The file to use as the debian conffiles file */
+    private File confFiles = null;
+    
     /** The compression method used for the data file (none, gzip or bzip2) */
     private String compression = "gzip";
 
@@ -98,6 +103,9 @@ public class DebMaker {
         }
     }
 
+    public void setConfFiles(File confFiles) {
+        this.confFiles = confFiles;
+    }
     public void setDeb(File deb) {
         this.deb = deb;
     }
@@ -209,8 +217,18 @@ public class DebMaker {
             throw new PackagingException(
                     "You need to specify where the deb file is supposed to be created.");
         }
-
-        final File[] controlFiles = control.listFiles();
+        
+        File[] controlFiles = control.listFiles();
+        
+        final File staticConfFiles = new File(control, "conffiles");
+        if (staticConfFiles.exists() && confFiles != null && controlFiles.length > 0) {
+            console.println("WARNING: The confFiles rules in the pom will be overriden by "+staticConfFiles.getAbsolutePath());                    
+        } else if (confFiles != null) {
+            List<File> files = new ArrayList<File>(Arrays.asList(controlFiles));
+            files.add(confFiles);
+            controlFiles = files.toArray(controlFiles);
+        }
+        
 
         final DataProducer[] data = new DataProducer[dataProducers.size()];
         dataProducers.toArray(data);

--- a/src/main/java/org/vafer/jdeb/maven/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMaker.java
@@ -222,7 +222,7 @@ public class DebMaker {
         
         final File staticConfFiles = new File(control, "conffiles");
         if (staticConfFiles.exists() && confFiles != null && controlFiles.length > 0) {
-            console.println("WARNING: The confFiles rules in the pom will be overriden by "+staticConfFiles.getAbsolutePath());                    
+            console.warn("The confFiles rules in the pom will be overriden by "+staticConfFiles.getAbsolutePath());                    
         } else if (confFiles != null) {
             List<File> files = new ArrayList<File>(Arrays.asList(controlFiles));
             files.add(confFiles);

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -407,6 +407,9 @@ public class DebMojo extends AbstractPluginMojo {
                 public void println(String s) {
                     getLog().info(s);
                 }
+                public void warn(String message) {
+                    getLog().warn(message);
+                }
             };
 
             try {

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -271,31 +271,33 @@ public class DebMojo extends AbstractPluginMojo {
         File generatedConfFiles = null;
 
         List<File> allConfigFiles = new ArrayList<File>();
-        
-        FileSetManager fileSetManager = new FileSetManager();
-        for (FileSet nextFileSet : confFiles) {
-            List<String> configFileNames = new ArrayList<String>();
 
-            configFileNames.addAll(Arrays.asList(fileSetManager.getIncludedFiles(nextFileSet)));
-            configFileNames.addAll(Arrays.asList(fileSetManager.getIncludedDirectories(nextFileSet)));
+        if (confFiles != null) {
+            FileSetManager fileSetManager = new FileSetManager();
+            for (FileSet nextFileSet : confFiles) {
+                List<String> configFileNames = new ArrayList<String>();
 
-            for (String nextFileName : configFileNames) {
-                allConfigFiles.add(new File(nextFileSet.getOutputDirectory(), nextFileName));
-            }
-        }
+                configFileNames.addAll(Arrays.asList(fileSetManager.getIncludedFiles(nextFileSet)));
+                configFileNames.addAll(Arrays.asList(fileSetManager.getIncludedDirectories(nextFileSet)));
 
-        if (!allConfigFiles.isEmpty()) {
-            PrintWriter printWriter = null;
-            generatedConfFiles = new File(Files.createTempDir(), "conffiles");
-            try {                
-                printWriter = new PrintWriter(new FileOutputStream(generatedConfFiles));
-                for (File nextFileName : allConfigFiles) {
-                    printWriter.println(nextFileName.getAbsolutePath());
+                for (String nextFileName : configFileNames) {
+                    allConfigFiles.add(new File(nextFileSet.getOutputDirectory(), nextFileName));
                 }
-            } catch (IOException e) {
-                throw new MojoExecutionException("Failed to write to temporary conffiles file - "+generatedConfFiles.getAbsolutePath(), e);
-            } finally {
-                printWriter.close();
+            }
+
+            if (!allConfigFiles.isEmpty()) {
+                PrintWriter printWriter = null;
+                generatedConfFiles = new File(Files.createTempDir(), "conffiles");
+                try {
+                    printWriter = new PrintWriter(new FileOutputStream(generatedConfFiles));
+                    for (File nextFileName : allConfigFiles) {
+                        printWriter.println(nextFileName.getAbsolutePath());
+                    }
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Failed to write to temporary conffiles file - " + generatedConfFiles.getAbsolutePath(), e);
+                } finally {
+                    printWriter.close();
+                }
             }
         }
 

--- a/src/test/java/org/vafer/jdeb/DataProducerTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DataProducerTestCase.java
@@ -39,6 +39,8 @@ public final class DataProducerTestCase extends TestCase {
         final Processor processor = new Processor(new Console() {
             public void println(String s) {
             }
+            public void warn(String message) {
+            }
         }, null);
 
         final File control = new File(getClass().getResource("deb/control/control").toURI());

--- a/src/test/java/org/vafer/jdeb/ProcessorTestCase.java
+++ b/src/test/java/org/vafer/jdeb/ProcessorTestCase.java
@@ -33,6 +33,9 @@ public class ProcessorTestCase extends TestCase {
         Processor processor = new Processor(new Console() {
             public void println(String s) {
             }
+
+            public void warn(String message) {
+            }
         }, null);
 
         Project project = new Project();


### PR DESCRIPTION
This adds the ability to specify the config files of a package in the pom, using standard filesets.

A conffiles file is generated so that config files will not be deleted without --purge, and will ask the user if the files should be kept if both they and the maintainer have updated the package.

This can be achieved through manual maintenance of a conffiles file in the control directory, but using filesets allows wildcards & exclusions etc. 