### PR TITLE
Override Version if the DEBVERSION environment variable is specified

### DIFF
--- a/src/main/java/org/vafer/jdeb/Processor.java
+++ b/src/main/java/org/vafer/jdeb/Processor.java
@@ -388,6 +388,14 @@ public class Processor {
 
         packageDescriptor.set("Installed-Size", pDataSize.divide(BigInteger.valueOf(1024)).toString());
 
+        // override the Version if the DEBVERSION environment variable is defined
+        final String debVersion = System.getenv("DEBVERSION");
+        if (debVersion != null) {
+            packageDescriptor.set("Version", debVersion);
+            console.info("Using version'" + debVersion + "' from the environment variables.");
+        }
+
+
         // override the Maintainer field if the DEBFULLNAME and DEBEMAIL environment variables are defined
         final String debFullName = System.getenv("DEBFULLNAME");
         final String debEmail = System.getenv("DEBEMAIL");


### PR DESCRIPTION
This allows for the Version to be specified by an environment variable. This is helpful in cases where the version is derived partially by a commit hash (git), build date or other data that is constantly changing.
