### PR TITLE
added System.getProperties to the VariableResolver

### DIFF
--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -271,6 +271,7 @@ public class DebMojo extends AbstractPluginMojo {
 
     protected VariableResolver initializeVariableResolver( Map<String, String> variables ) {
         ((Map) variables).putAll(getProject().getProperties());
+        ((Map) variables).putAll(System.getProperties());
         variables.put("name", name != null ? name : getProject().getName());
         variables.put("artifactId", getProject().getArtifactId());
         variables.put("groupId", getProject().getGroupId());


### PR DESCRIPTION
this helps with "mvn package -Denvironment=test" to replace [[environment]] in the control-file.
so the package name could be [[name]]-[[environment]].
this is helpfull for projects with a development and production stage to build and deploy a package for the needed environment without the need of a 2nd branch or changes in the code. and later the same sourcecode can be used to build a package for an other environment.
