### PR TITLE
Change default value Distribution/Urgency in the changes file, when no CHANGES.txt is  provided

### DIFF
--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -243,8 +243,13 @@ public class DebMaker {
                     @Override
                     public ChangeSet[] getChangesSets() {
                         return new ChangeSet[] {
-                                new ChangeSet(packageControlFile.get("Package"), packageControlFile.get("Version"), new Date(),
-                                        "stable", "low", packageControlFile.get("Maintainer"), new String[0])
+                                new ChangeSet(packageControlFile.get("Package"),
+                                        packageControlFile.get("Version"),
+                                        new Date(),
+                                        packageControlFile.get("Distribution") == null ? "stable" : packageControlFile.get("Distribution"),
+                                        packageControlFile.get("Urgency") == null ? "low" : packageControlFile.get("Urgency"),
+                                        packageControlFile.get("Maintainer"),
+                                        new String[0])
                         };
                     }
                 };

--- a/src/main/java/org/vafer/jdeb/debian/ChangesFile.java
+++ b/src/main/java/org/vafer/jdeb/debian/ChangesFile.java
@@ -53,7 +53,6 @@ public final class ChangesFile extends ControlFile {
 
     public ChangesFile() {
         set("Format", "1.8");
-        set("Distribution", "stable");
     }
 
     /**
@@ -69,6 +68,7 @@ public final class ChangesFile extends ControlFile {
         set("Version",      packageControlFile.get("Version"));
         set("Maintainer",   packageControlFile.get("Maintainer"));
         set("Changed-By",   packageControlFile.get("Maintainer"));
+        set("Distribution", packageControlFile.get("Distribution") == null ? "stable": packageControlFile.get("Distribution"));
         
         StringBuilder description = new StringBuilder();
         description.append(packageControlFile.get("Package"));


### PR DESCRIPTION
I provided a patch a default string "stable" was used for Distribution, "low" for the urgency even if i wrote in the control file with the following content

Distribution: snapshot
Urgency: high

here my jdeb maven configuration plugin

``` xml
<configuration>
<deb>${project.build.directory}/debian/${project.name}_${project.version}${buildNumber}_all.deb</deb>
<changesOut>${project.build.directory}/debian/${project.name}_${project.version}${buildNumber}_all.changes</changesOut>
<verbose>true</verbose>
<controlDir>${project.build.directory}/control</controlDir>

...
</configuration>
```
