### PR TITLE
Fix a problem with filemode in the ant task

### DIFF
--- a/src/main/java/org/vafer/jdeb/ant/Mapper.java
+++ b/src/main/java/org/vafer/jdeb/ant/Mapper.java
@@ -39,8 +39,8 @@ public final class Mapper {
     private int gid = -1;
     private String user;
     private String group;
-    private int fileMode = -1;
-    private int dirMode = -1;
+    private String fileMode;
+    private String dirMode;
 
     public void setType( final String pType ) {
         mapperType = pType;
@@ -76,11 +76,11 @@ public final class Mapper {
         group = pGroup;
     }
 
-    public void setFileMode( final int pFileMode ) {
+    public void setFileMode( final String pFileMode ) {
         fileMode = pFileMode;
     }
 
-    public void setDirMode( int pDirMode ) {
+    public void setDirMode( final String pDirMode ) {
         dirMode = pDirMode;
     }
 

--- a/src/test/java/org/vafer/jdeb/ant/DebAntTaskTestCase.java
+++ b/src/test/java/org/vafer/jdeb/ant/DebAntTaskTestCase.java
@@ -225,6 +225,21 @@ public final class DebAntTaskTestCase extends TestCase {
         assertTrue("Link not found", linkFound.get());
     }
 
+    public void testMapper() throws Exception {
+        project.executeTarget("perm-mapper");
+
+        File deb = new File("target/test-classes/test.deb");
+        assertTrue("package not build", deb.exists());
+
+        ArchiveWalker.walkData(deb, new ArchiveVisitor<TarArchiveEntry>() {
+            public void visit(TarArchiveEntry entry, byte[] content) throws IOException {
+                if (entry.isFile()) {
+                    assertEquals("file mode (" + entry.getName() + ")", 0700, entry.getMode());
+                }
+            }
+        }, Compression.GZIP);
+    }
+
     public void testUnkownCompression() throws Exception {
         try {
             project.executeTarget("unknown-compression");

--- a/src/test/resources/testbuild.xml
+++ b/src/test/resources/testbuild.xml
@@ -87,6 +87,14 @@
     </deb>
   </target>
 
+  <target name="perm-mapper">
+    <deb destfile="test.deb" control="org/vafer/jdeb/deb/control">
+      <data src="org/vafer/jdeb/deb/data" type="directory">
+        <mapper type="perm" filemode="700" prefix="/usr/share/foo"/>
+      </data>
+    </deb>
+  </target>
+
   <target name="unknown-compression">
     <deb destfile="test.deb" control="org/vafer/jdeb/deb/control" compression="rar">
       <fileset dir="org/vafer/jdeb/deb/data"/>


### PR DESCRIPTION
The file mode should be a string in the Ant task so that it will be
passed as a String to the PermMapper where the right Constructor will
convert it to an int using parseInt(mode, 8).
