### PR TITLE
Don't use "default-jre | java6-runtime" as default depends

### DIFF
--- a/src/main/java/org/vafer/jdeb/debian/ControlFile.java
+++ b/src/main/java/org/vafer/jdeb/debian/ControlFile.java
@@ -98,22 +98,19 @@ public abstract class ControlFile {
     }
 
     public void set(String field, final String value) {
-        if (!"".equals(field)) {
+        if (field != null && isUserDefinedField(field)) {
+            userDefinedFields.put(field, value);
+            String fieldName = getUserDefinedFieldName(field);
 
-            if (isUserDefinedField(field)) {
-                userDefinedFields.put(field, value);
-                String fieldName = getUserDefinedFieldName(field);
-
-                if (fieldName != null) {
-                    userDefinedFieldNames.add(new ControlField(fieldName));
-                }
-
-                field = fieldName;
+            if (fieldName != null) {
+                userDefinedFieldNames.add(new ControlField(fieldName));
             }
 
-            if (field != null) {
-                values.put(field, value);
-            }
+            field = fieldName;
+        }
+
+        if (field != null && !"".equals(field)) {
+            values.put(field, value);
         }
     }
 


### PR DESCRIPTION
I'm creating a package with jdeb that has no dependencies. In that case jdeb sets "default-jre | java6-runtime" as default dependencies and the package can't be installed without installing the java dependencies (which are not needed at all)
