### PR TITLE
Cumulative patch with refactored Raniz's changes

### DIFF
--- a/docs/maven.md
+++ b/docs/maven.md
@@ -86,9 +86,11 @@ changesIn     | The changes to add                                              
 changesOut    | The changes file generated                                                   | No
 changesSave   | (NYI) The merged changes file                                                | No
 compression   | (NYI) Compression method for the data file (`gzip`, `bzip2`, `xz` or `none`) | No; defaults to `gzip`
-keyring       | (NYI) The file containing the PGP keys                                       | No
-key           | (NYI) The name of the key to be used in the keyring                          | No
-passphrase    | (NYI) The passphrase to use the key                                          | No
+signPackage   | If the debian package should be signed                                       | No
+signCfgPrefix | Prefix for when reading keyring, key and passphrase from settings.xml        | No; defaults to `jdeb.`
+keyring       | The file containing the PGP keys                                             | No
+key           | The name of the key to be used in the keyring                                | No
+passphrase    | The passphrase to use the key                                                | No
 attach        | Attach artifact to project                                                   | No; defaults to `true`
 submodules    | Execute the goal on all sub-modules                                          | No; defaults to `true`
 timestamped   | Turn SNAPSHOT into timestamps                                                | No; defaults to `false`
@@ -129,7 +131,7 @@ dirmode       | Dir permissions as octet                              | No; defa
 strip         | Strip n path components from the original file        | No; defaults to 0
 
 Below is an example of how you could configure your jdeb maven plugin to
-include a directory, a tarball, and a file in your deb package:
+include a directory, a tarball, and a file in your deb package and then sign it with the key 8306FE21 in /home/user/.gnupg/secring.gpg:
 
 ```xml
   <build>
@@ -145,6 +147,10 @@ include a directory, a tarball, and a file in your deb package:
               <goal>jdeb</goal>
             </goals>
             <configuration>
+              <signPackage>true</signPackage>
+              <keyring>/home/user/.gnupg/secring.gpg</keyring>
+              <key>8306FE21</key>
+              <passphrase>abcdef</passphrase>
 
               <dataSet>
 
@@ -219,3 +225,22 @@ include a directory, a tarball, and a file in your deb package:
     </plugins>
   </build>
 ```
+If you don't want to store your key information in the POM you can store this is your settings.xml, here's an example settings.xml:
+
+    <settings>
+        <profiles>
+            <profile>
+                <id>jdeb-signing</id>
+                <properties>
+                    <jdeb.keyring>/home/user/.gnupg/secring.gpg</jdeb.keyring>
+                    <jdeb.key>8306FE21</jdeb.key>
+                    <jdeb.passphrase>abcdef</jdeb.passphrase>
+                </properties>
+            </profile>
+        </profiles>
+        <activeProfiles>
+            <activeProfile>jdeb-signing</activeProfile>
+        </activeProfiles>
+    </settings>
+
+keyring, key and passphrase can then be omitted from the POM entirely.

--- a/pom.xml
+++ b/pom.xml
@@ -118,16 +118,32 @@
                         <configuration>
                             <!-- <dependencyReducedPomLocation>${basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation> -->
                             <minimizeJar>true</minimizeJar>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes>
                                     <include>org.apache.commons:commons-compress</include>
                                     <include>commons-io:commons-io</include>
+                                    <include>org.bouncycastle:bcpg-jdk15on</include>
+                                    <include>org.bouncycastle:bcprov-jdk15on</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.commons</pattern>
                                     <shadedPattern>org.vafer.jdeb.shaded.compress</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.bouncycastle</pattern>
+                                    <shadedPattern>org.vafer.jdeb.shaded.bc</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/src/main/java/org/vafer/jdeb/signing/PGPSigner.java
+++ b/src/main/java/org/vafer/jdeb/signing/PGPSigner.java
@@ -50,10 +50,15 @@ public class PGPSigner {
 
     private static final byte[] EOL = "\r\n".getBytes(Charset.forName("UTF-8"));
 
+    private PGPSecretKey secretKey;
     private PGPPrivateKey privateKey;
 
     public PGPSigner(InputStream keyring, String keyId, String passphrase) throws IOException, PGPException {
-        PGPSecretKey secretKey = getSecretKey(keyring, keyId);
+        secretKey = getSecretKey(keyring, keyId);
+        if(secretKey == null)
+        {
+            throw new PGPException(String.format("Specified key %s does not exist in key ring %s", keyId, keyring));
+        }
         privateKey = secretKey.extractPrivateKey(new BcPBESecretKeyDecryptorBuilder(new BcPGPDigestCalculatorProvider()).build(passphrase.toCharArray()));
     }
 
@@ -104,6 +109,22 @@ public class PGPSigner {
         armoredOutput.close();
     }
     
+    /**
+     * Returns the secret key.
+     */
+    public PGPSecretKey getSecretKey()
+    {
+        return secretKey;
+    }
+
+    /**
+     * Returns the private key.
+     */
+    public PGPPrivateKey getPrivateKey()
+    {
+        return privateKey;
+    }
+
     /**
      * Returns the secret key matching the specified identifier.
      * 

--- a/src/main/java/org/vafer/jdeb/utils/PGPSignatureOutputStream.java
+++ b/src/main/java/org/vafer/jdeb/utils/PGPSignatureOutputStream.java
@@ -1,0 +1,70 @@
+package org.vafer.jdeb.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.SignatureException;
+
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.PGPSignatureGenerator;
+
+/**
+ * An output stream that calculates the signature of the input data as it
+ * is written
+ * 
+ * @author mpoindexter
+ *
+ */
+public class PGPSignatureOutputStream extends OutputStream {
+    private final PGPSignatureGenerator signatureGenerator;
+
+    public PGPSignatureOutputStream( PGPSignatureGenerator signatureGenerator ) {
+        super();
+        this.signatureGenerator = signatureGenerator;
+    }
+
+    public void write( int b ) throws IOException {
+        try {
+            signatureGenerator.update(new byte[] { (byte)b });
+        } catch(SignatureException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public void write( byte[] b ) throws IOException {
+        try {
+            signatureGenerator.update(b);
+        } catch(SignatureException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public void write( byte[] b, int off, int len ) throws IOException {
+        try {
+            signatureGenerator.update(b, off, len);
+        } catch(SignatureException e) {
+            throw new IOException(e);
+        }
+    }
+    
+    public PGPSignature generateSignature() throws SignatureException, PGPException {
+        return signatureGenerator.generate();
+    }
+    
+    public String generateASCIISignature() throws SignatureException, PGPException {
+        try {
+            PGPSignature signature = generateSignature();
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            ArmoredOutputStream armorStream = new ArmoredOutputStream(buffer);
+            signature.encode(armorStream);
+            armorStream.close();
+            return new String(buffer.toByteArray());
+        } catch(IOException e) {
+            //Should never happen since we are just using a memory buffer
+            throw new RuntimeException(e);
+        }
+    }
+
+} 

--- a/src/main/java/org/vafer/jdeb/utils/Utils.java
+++ b/src/main/java/org/vafer/jdeb/utils/Utils.java
@@ -16,12 +16,18 @@
 package org.vafer.jdeb.utils;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.util.Date;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -88,7 +94,6 @@ public final class Utils {
         }
         return s;
     }
-
 
     /**
      * Substitute the variables in the given expression with the
@@ -199,5 +204,128 @@ public final class Utils {
         version = version.replace('-', '+');
         
         return version;
+    }
+
+    /**
+     * Extracts value from map if given value is null.
+     * @param value current value
+     * @param props properties to extract value from
+     * @param key property name to extract
+     * @return initial value or value extracted from map
+     */
+    public static String lookupIfEmpty( final String value,
+                                        final Map<String, String> props,
+                                        final String key ) {
+        return value != null ? value : props.get(key);
+    }
+    
+    /**
+     * Get the known locations where the secure keyring can be located.
+     * Looks through known locations of the GNU PG secure keyring.
+     * 
+     * @return The location of the PGP secure keyring if it was found,
+     *         null otherwise
+     */
+    public static Collection<String> getKnownPGPSecureRingLocations() {
+        final LinkedHashSet<String> locations = new LinkedHashSet<String>();
+
+        final String os = System.getProperty("os.name");
+        final boolean runOnWindows = os == null || os.toLowerCase().contains("win");
+
+        if (runOnWindows) {
+            // The user's roaming profile on Windows, via environment
+            final String windowsRoaming = System.getenv("APPDATA");
+            if (windowsRoaming != null) {
+                locations.add(joinPaths(windowsRoaming, "gnupg", "secring.gpg"));
+            }
+
+            // The user's local profile on Windows, via environment
+            final String windowsLocal = System.getenv("LOCALAPPDATA");
+            if (windowsLocal != null) {
+                locations.add(joinPaths(windowsLocal, "gnupg", "secring.gpg"));
+            }
+
+            // The Windows installation directory
+            final String windir = System.getProperty("WINDIR");
+            if (windir != null) {
+                // Local Profile on Windows 98 and ME
+                locations.add(joinPaths(windir, "Application Data", "gnupg", "secring.gpg"));
+            }
+        }
+
+        final String home = System.getProperty("user.home");
+
+        if (home != null && runOnWindows) {
+            // These are for various flavours of Windows
+            // if the environment variables above have failed
+
+            // Roaming profile on Vista and later
+            locations.add(joinPaths(home, "AppData", "Roaming", "gnupg", "secring.gpg"));
+            // Local profile on Vista and later
+            locations.add(joinPaths(home, "AppData", "Local", "gnupg", "secring.gpg"));
+            // Roaming profile on 2000 and XP
+            locations.add(joinPaths(home, "Application Data", "gnupg", "secring.gpg"));
+            // Local profile on 2000 and XP
+            locations.add(joinPaths(home, "Local Settings", "Application Data", "gnupg", "secring.gpg"));
+        }
+
+        // *nix, including OS X
+        if (home != null) {
+            locations.add(joinPaths(home, ".gnupg", "secring.gpg"));
+        }
+
+        return locations;
+    }
+
+    /**
+     * Tries to guess location of the user secure keyring using various
+     * heuristics.
+     *
+     * @return path to the keyring file
+     * @throws FileNotFoundException if no keyring file found
+     */
+    public static File guessKeyRingFile() throws FileNotFoundException {
+        final Collection<String> possibleLocations = getKnownPGPSecureRingLocations();
+        for (final String location : possibleLocations) {
+            final File candidate = new File(location);
+            if (candidate.exists()) {
+                return candidate;
+            }
+        }
+        final StringBuilder message = new StringBuilder("Could not locate secure keyring, locations tried: ");
+        final Iterator<String> it = possibleLocations.iterator();
+        while (it.hasNext()) {
+            message.append(it.next());
+            if (it.hasNext()) {
+                message.append(", ");
+            }
+        }
+        throw new FileNotFoundException(message.toString());
+    }
+
+    /**
+     * Join together path elements with File.separator. Filters out null
+     * elements.
+     * 
+     * @param elements The path elements to join
+     * @return elements concatenated together with File.separator
+     */
+    public static String joinPaths(String... elements) {
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        for (String element : elements) {
+            // Skip null elements
+            if (element == null) {
+                // This won't change the value of first if we skip elements
+                // in the beginning of the array
+                continue;
+            }
+            if (!first) {
+                builder.append(File.separatorChar);
+            }
+            builder.append(element);
+            first = false;
+        }
+        return builder.toString();
     }
 }


### PR DESCRIPTION
Support for package signing for maven plugin, including:
- Automatic lookup of secure ring location (keyring) if not set.
- Support for reading signing properties (keyring, key and
  passphrase) from settings, allowing storage of sensitive information
  outside the pom.
- Configurable prefix to define different keys for different packages,
  the default prefix is "jdeb." resulting in the properties
  jdeb.keyring, jdeb.key and jdeb.passphrase being read from the
  properties in the active profiles.
- Log message stating that we're signing the `.deb`.
- Documentation for signing packages.

The code is mostly the one written by Raniz, but it renewed and reformatted a little bit to better conform surrounding code style. I've tested the result on a simple module and I was able to build and sign my package using both `pom.xml` and `settings.xml` configurations on my Linux machine (unfortunately, I don't have a windows installation to test the thing). I've also renamed maven parameter `signParameterPrefix` -> `signCfgPrefix` to keep parameter names short. I've also added some warning suppression annotations to make my IDE happier.
