### PR TITLE
Add support of man-page producers.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 * [CHG] Alpha, Beta and RC versions are transformed to a package version ordered before the final release (ex: 1.0~RC1)
 * [FIX] Permission mappers now work properly with Ant (Thanks to Christian Egli)
 * [FIX] Symbolic links longer than 100 characters are now supported
+* [FIX] The signed changes files now pass the validation with gpg --verify (Thanks to Max Garmash and Roman Kashitsyn)
 
 ## Version 1.0.1, released 28.02.2013
 

--- a/docs/ant.md
+++ b/docs/ant.md
@@ -166,3 +166,19 @@ Then you can sign your changes file with:
 <b>Security Note</b>: Hard coding the passphrase in the `<deb>` task can be a serious
 security hole. Consider using variable substitution and asking the passphrase
 to the user with the `<input>` task, or retrieving it from a secured `.properties` file.
+
+## Conffiles file
+
+If you package up a directory as Debian package you can also add the affected files to
+the conffiles file. You only have to set the `conffile` attribute to `true`.
+
+```xml
+    <target name="package">
+      <taskdef name="deb" classname="org.vafer.jdeb.ant.DebAntTask"/>
+      <deb destfile="jdeb.deb" control="${deb}/control">
+        <data src="src/main/resources/deb/data" type="directory" conffile="true">
+          <exclude name="**/.svn"/>
+        </data>
+      </deb>
+    </target>
+```

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -113,6 +113,7 @@ type             | Type of the data source. (archive, directory, file, link, man
 missingSrc       | Fail if src file/folder is missing (ignore or fail)                             | No; defaults to `fail`
 includes         | A comma seperated list of files to include from the directory or tarball        | No; defaults to all files
 excludes         | A comma seperated list of files to exclude from the directory or tarball        | No; defaults to no exclutions
+conffile         | A boolean value to define if the files should be included in the conffiles      | No; defaults to `false`
 mapper           | The files to exclude from the directory or tarball                              | No
 paths/(path..)   | One or more string literal paths that will created in the package               | No; Yes for type `template`
 
@@ -221,6 +222,19 @@ include a directory, a tarball, and a file in your deb package and then sign it 
                 <data>
                   <type>man-page</type>
                   <src>/a/path/to/manpage.1</src>
+                </data>
+
+                <!-- Conffiles example -->
+                <data>
+                  <src>${project.build.directory}/data</src>
+                  <type>directory</type>
+                  <includes/>
+                  <excludes>**/.svn</excludes>
+                  <conffile>true</conffile>
+                  <mapper>
+                    <type>ls</type>
+                    <src>mapping.txt</src>
+                  </mapper>
                 </data>
               </dataSet>
 

--- a/src/main/java/org/vafer/jdeb/ControlBuilder.java
+++ b/src/main/java/org/vafer/jdeb/ControlBuilder.java
@@ -27,6 +27,7 @@ import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
@@ -74,7 +75,7 @@ class ControlBuilder {
      * @throws java.io.IOException
      * @throws java.text.ParseException
      */
-    void buildControl(BinaryPackageControlFile packageControlFile, File[] controlFiles, StringBuilder checksums, File output) throws IOException, ParseException {
+    void buildControl(BinaryPackageControlFile packageControlFile, File[] controlFiles, List<String> conffiles, StringBuilder checksums, File output) throws IOException, ParseException {
         final File dir = output.getParentFile();
         if (dir != null && (!dir.exists() || !dir.isDirectory())) {
             throw new IOException("Cannot write control file at '" + output.getAbsolutePath() + "'");
@@ -82,6 +83,8 @@ class ControlBuilder {
 
         final TarArchiveOutputStream outputStream = new TarArchiveOutputStream(new GZIPOutputStream(new FileOutputStream(output)));
         outputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+        
+        boolean foundConffiles = false;
         
         // create the final package control file out of the "control" file, copy all other files, ignore the directories
         for (File file : controlFiles) {
@@ -93,6 +96,10 @@ class ControlBuilder {
                 continue;
             }
 
+            if ("conffiles".equals(file.getName())) {
+            	foundConffiles = true;
+            }
+            
             if (CONFIGURATION_FILENAMES.contains(file.getName()) || MAINTAINER_SCRIPTS.contains(file.getName())) {
                 FilteredFile configurationFile = new FilteredFile(new FileInputStream(file), resolver);
                 addControlEntry(file.getName(), configurationFile.toString(), outputStream);
@@ -115,15 +122,37 @@ class ControlBuilder {
                 in.close();
             }
         }
+        
+        if ((conffiles != null) && (conffiles.size() > 0)) {
+        	if (foundConffiles) {
+        		console.info("Found file 'conffiles' in the control directory. Skipping conffiles generation.");
+        	} else {
+	            addControlEntry("conffiles", createPackageConffilesFile(conffiles), outputStream);
+	        }
+        } else if ((conffiles != null) && (conffiles.size() == 0)) {
+        	console.info("Skipping 'conffiles' generation. No entries provided.");
+        }
 
         if (packageControlFile == null) {
-            throw new FileNotFoundException("No 'control' file found in " + Arrays.toString(controlFiles));
+            throw new FileNotFoundException("No 'control' file found in " + controlFiles.toString());
         }
         
         addControlEntry("control", packageControlFile.toString(), outputStream);
         addControlEntry("md5sums", checksums.toString(), outputStream);
 
         outputStream.close();
+    }
+    
+    private String createPackageConffilesFile(final List<String> conffiles) {
+        StringBuilder content = new StringBuilder();
+    	
+    	if (conffiles != null && !conffiles.isEmpty()) {
+            for (String nextFileName : conffiles) {
+                content.append(nextFileName).append("\n");
+            }
+        }
+
+        return content.toString();
     }
     
     

--- a/src/main/java/org/vafer/jdeb/DataBuilder.java
+++ b/src/main/java/org/vafer/jdeb/DataBuilder.java
@@ -119,7 +119,7 @@ class DataBuilder {
 
                 console.debug("dir: " + dirname);
             }
-
+            
             public void onEachFile( InputStream inputStream, String filename, String linkname, String user, int uid, String group, int gid, int mode, long size ) throws IOException {
                 // Check link name
                 checkField(linkname, TarConstants.NAMELEN);

--- a/src/main/java/org/vafer/jdeb/DataConsumer.java
+++ b/src/main/java/org/vafer/jdeb/DataConsumer.java
@@ -28,7 +28,7 @@ public interface DataConsumer {
     void onEachDir( String dirname, String linkname, String user, int uid, String group, int gid, int mode, long size ) throws IOException;
 
     void onEachFile( InputStream input, String filename, String linkname, String user, int uid, String group, int gid, int mode, long size ) throws IOException;
-
+    
     void onEachLink( String path, String linkName, boolean symlink, String user, int uid, String group, int gid, int mode) throws IOException;
 
 }

--- a/src/main/java/org/vafer/jdeb/ant/Data.java
+++ b/src/main/java/org/vafer/jdeb/ant/Data.java
@@ -43,6 +43,8 @@ public final class Data extends PatternSet implements DataProducer {
 
     private String type;
 
+    private Boolean conffile;
+
     private String destinationName;
 
     public void setSrc(File src) {
@@ -55,6 +57,14 @@ public final class Data extends PatternSet implements DataProducer {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public void setConffile(Boolean conffile) {
+        this.conffile = conffile;
+    }
+    
+    public Boolean getConffile() {
+        return this.conffile;
     }
 
     public void setDst(String destinationName) {

--- a/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
+++ b/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
@@ -72,6 +72,7 @@ public class DebAntTask extends MatchingTask {
     private Collection<Link> links = new ArrayList<Link>();
 
     private Collection<DataProducer> dataProducers = new ArrayList<DataProducer>();
+    private Collection<DataProducer> conffilesProducers = new ArrayList<DataProducer>();
 
 
     public void setDestfile( File deb ) {
@@ -145,12 +146,15 @@ public class DebAntTask extends MatchingTask {
                 } else if (!Arrays.asList("file", "directory", "archive").contains(data.getType().toLowerCase())) {
                     throw new BuildException("The type '" + data.getType() + "' of the data element is unknown (expected 'file', 'directory' or 'archive')");
                 }
+                if (data.getConffile() != null && data.getConffile()) {
+                    conffilesProducers.add(dataProducer);
+                }
             }
         }
         
         Console console = new TaskConsole(this, verbose);
         
-        DebMaker debMaker = new DebMaker(console, dataProducers);
+        DebMaker debMaker = new DebMaker(console, dataProducers, conffilesProducers);
         debMaker.setDeb(deb);
         debMaker.setControl(control);
         debMaker.setChangesIn(changesIn);

--- a/src/main/java/org/vafer/jdeb/maven/Data.java
+++ b/src/main/java/org/vafer/jdeb/maven/Data.java
@@ -91,6 +91,19 @@ public final class Data implements DataProducer {
     public void setSymlink(boolean symlink) {
         this.symlink = symlink;
     }
+    
+    private boolean conffile = false;
+
+    /**
+     * @parameter expression="${conffile}"
+     */
+    public void setConffile(boolean conffile) {
+        this.conffile = conffile;
+    }
+    
+    public boolean getConffile() {
+        return this.conffile;
+    }
 
     @Parameter(alias = "includes")
     private String[] includePatterns;

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -280,6 +280,7 @@ public class DebMojo extends AbstractPluginMojo {
     private String closeReplaceToken = "]]";
     private Console console;
     private Collection<DataProducer> dataProducers = new ArrayList<DataProducer>();
+    private Collection<DataProducer> conffileProducers = new ArrayList<DataProducer>();
 
     public void setOpenReplaceToken( String openReplaceToken ) {
         this.openReplaceToken = openReplaceToken;
@@ -296,8 +297,15 @@ public class DebMojo extends AbstractPluginMojo {
     protected void setData( Data[] dataSet ) {
         this.dataSet = dataSet;
         dataProducers.clear();
+        conffileProducers.clear();
         if (dataSet != null) {
             Collections.addAll(dataProducers, dataSet);
+            
+            for (Data item : dataSet) {
+                if (item.getConffile()) {
+                    conffileProducers.add(item);
+                }
+            }
         }
     }
 
@@ -450,7 +458,7 @@ public class DebMojo extends AbstractPluginMojo {
         }
 
         try {
-            DebMaker debMaker = new DebMaker(console, dataProducers);
+            DebMaker debMaker = new DebMaker(console, dataProducers, conffileProducers);
             debMaker.setDeb(debFile);
             debMaker.setControl(controlDirFile);
             debMaker.setPackage(getProject().getArtifactId());

--- a/src/main/java/org/vafer/jdeb/signing/PGPSigner.java
+++ b/src/main/java/org/vafer/jdeb/signing/PGPSigner.java
@@ -16,7 +16,6 @@
 
 package org.vafer.jdeb.signing;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +25,7 @@ import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.Iterator;
 
+import org.apache.commons.io.LineIterator;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.openpgp.PGPException;
@@ -87,10 +87,11 @@ public class PGPSigner {
         ArmoredOutputStream armoredOutput = new ArmoredOutputStream(output);
         armoredOutput.beginClearText(digest);
         
-        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        LineIterator iterator = new LineIterator(new InputStreamReader(input));
         
-        String line;
-        while ((line = reader.readLine()) != null) {
+        while (iterator.hasNext()) {
+            String line = iterator.nextLine();
+            
             // trailing spaces must be removed for signature calculation (see http://tools.ietf.org/html/rfc4880#section-7.1)
             byte[] data = trim(line).getBytes("UTF-8");
             
@@ -98,7 +99,9 @@ public class PGPSigner {
             armoredOutput.write(EOL);
             
             signatureGenerator.update(data);
-            signatureGenerator.update(EOL);
+            if (iterator.hasNext()) {
+                signatureGenerator.update(EOL);
+            }
         }
 
         armoredOutput.endClearText();

--- a/src/test/java/org/vafer/jdeb/DebMakerTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DebMakerTestCase.java
@@ -55,7 +55,7 @@ public class DebMakerTestCase extends TestCase {
 
         File deb = File.createTempFile("jdeb", ".deb");
 
-        DebMaker maker = new DebMaker(new NullConsole(), Arrays.asList(data));
+        DebMaker maker = new DebMaker(new NullConsole(), Arrays.asList(data), null);
         maker.setControl(new File(getClass().getResource("deb/control").toURI()));
         maker.setDeb(deb);
         
@@ -88,7 +88,8 @@ public class DebMakerTestCase extends TestCase {
         }
         
         Collection<DataProducer> producers = Arrays.asList(new DataProducer[] {new EmptyDataProducer()});
-        DebMaker maker = new DebMaker(new NullConsole(), producers);
+        Collection<DataProducer> conffileProducers = Arrays.asList(new DataProducer[] {new EmptyDataProducer()});
+        DebMaker maker = new DebMaker(new NullConsole(), producers, conffileProducers);
         maker.setDeb(deb);
         maker.setControl(new File("target/test-classes/org/vafer/jdeb/deb/control"));
         
@@ -132,7 +133,8 @@ public class DebMakerTestCase extends TestCase {
         variables.put("version", "1.0");
         
         Collection<DataProducer> producers = Arrays.asList(new DataProducer[] {new EmptyDataProducer()});
-        DebMaker maker = new DebMaker(new NullConsole(), producers);
+        Collection<DataProducer> conffileProducers = Arrays.asList(new DataProducer[] {new EmptyDataProducer()});
+        DebMaker maker = new DebMaker(new NullConsole(), producers, conffileProducers);
         maker.setDeb(deb);
         maker.setControl(new File("target/test-classes/org/vafer/jdeb/deb/control"));
         maker.setResolver(new MapVariableResolver(variables));

--- a/src/test/java/org/vafer/jdeb/ant/DebAntTaskTestCase.java
+++ b/src/test/java/org/vafer/jdeb/ant/DebAntTaskTestCase.java
@@ -320,4 +320,10 @@ public final class DebAntTaskTestCase extends TestCase {
 
         assertTrue("tar file not found", found);
     }
+
+    public void testPackageConffiles() {
+        project.executeTarget("conffiles");
+
+        assertTrue("package not build", new File("target/test-classes/test.deb").exists());
+    }
 }

--- a/src/test/resources/testbuild.xml
+++ b/src/test/resources/testbuild.xml
@@ -119,4 +119,10 @@
     </deb>
   </target>
 
+  <target name="conffiles">
+    <deb destfile="test123.deb" control="org/vafer/jdeb/deb/control">
+      <data src="org/vafer/jdeb/deb/data" type="directory" conffile="true" />
+    </deb>
+  </target>
+
 </project>


### PR DESCRIPTION
Lintian wants a man page entry for every executable included into the
package and it wants them gzipped. It's inconvenient to add another
maven plugin to just gzip a man page entry during build. In addition,
it's not so easy to find a correct location for a man page using only
the Debian Policy Manual.

This patch provides a new `man-page` producer type that can guess
correct location for a page and gzip it. Unfortunately, it looks
impossible to gzip a page with maximal compression level as lintian
wants.

In addition, it removes some code duplication by introducing the
`Producers` package-private class to hold common constants and methods
and the `ProducerFactory` class to create producers from run-time
configuration in the ant task and the maven plugin.
