### PR TITLE
Add support of maven-encrypted passphrases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>1.4.1</version>
+            <version>1.5.15</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<component-set>
+    <components>
+        <component>
+            <role>org.sonatype.plexus.components.sec.dispatcher.SecDispatcher</role>
+            <role-hint>jdeb-sec</role-hint>
+            <implementation>org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher</implementation>
+            <requirements>
+                <requirement>
+                    <role>org.sonatype.plexus.components.cipher.PlexusCipher</role>
+                    <field-name>_cipher</field-name>
+                </requirement>
+            </requirements>
+            <configuration>
+                <_configuration-file>~/.m2/settings-security.xml</_configuration-file>
+            </configuration>
+        </component>
+        <component>
+            <role>org.sonatype.plexus.components.cipher.PlexusCipher</role>
+            <role-hint>jdeb-sec</role-hint>
+            <implementation>org.sonatype.plexus.components.cipher.DefaultPlexusCipher</implementation>
+        </component>
+    </components>
+</component-set>


### PR DESCRIPTION
- Add META-INF/plexus/components.xml resource with correct
  settings-security.xml file location. This is required
  due to https://github.com/sonatype/plexus-sec-dispatcher/pull/1
- Update plexus-utils version to have access to the
  org.codehaus.plexus.util.xml.XmlStreamReader
  The previous version caused an error on build.

See http://maven.apache.org/guides/mini/guide-encryption.html for
details.
