### PR TITLE
fix(#111): Implement `files` data producer

### DIFF
--- a/docs/maven.md
+++ b/docs/maven.md
@@ -109,7 +109,7 @@ src              | The directory, tarball, file to include in the package       
 dst              | New filename at destination (type must be `file`)                            | No
 linkName         | The path of the link (type must be `link`)                                   | Yes for link
 linkTarget       | The target of the link (type must be `link`)                                 | Yes for link
-type             | Type of the data source. (archive, directory, file, link or template)        | No; but will be Yes in the future
+type             | Type of the data source. (archive, directory, file, files, link or template) | No; but will be Yes in the future
 missingSrc       | Fail if src file/folder is missing (ignore or fail)                          | No; defaults to `fail`
 includes         | A comma seperated list of files to include from the directory or tarball     | No; defaults to all files
 excludes         | A comma seperated list of files to exclude from the directory or tarball     | No; defaults to no exclutions
@@ -127,7 +127,7 @@ uid           | Numerical uid                                         | No; defa
 gid           | Numerical gid                                         | No; defaults to 0
 user          | User name                                             | No; defaults to "root"
 group         | User group                                            | No; defaults to "root"
-filemode      | File permissions as octet                             | No; deftauls to 644
+filemode      | File permissions as octet                             | No; defaults to 644
 dirmode       | Dir permissions as octet                              | No; defaults to 755
 strip         | Strip n path components from the original file        | No; defaults to 0
 
@@ -191,6 +191,16 @@ include a directory, a tarball, and a file in your deb package and then sign it 
                   <missingSrc>ignore</missingSrc>
                 </data>
 
+                <!-- Multiple files example -->
+                <data>
+                  <type>files</type>
+                  <paths>
+                    <path>README.txt</path>
+                    <path>CHANGES.txt</path>
+                  </paths>
+                  <dst>/var/lib/${artifactId}</dst>
+                </data>
+
                 <!-- Template example -->
                 <data>
                   <type>template</type>
@@ -241,20 +251,21 @@ include a directory, a tarball, and a file in your deb package and then sign it 
 ```
 If you don't want to store your key information in the POM you can store this is your settings.xml, here's an example settings.xml:
 
-    <settings>
-        <profiles>
-            <profile>
-                <id>jdeb-signing</id>
-                <properties>
-                    <jdeb.keyring>/home/user/.gnupg/secring.gpg</jdeb.keyring>
-                    <jdeb.key>8306FE21</jdeb.key>
-                    <jdeb.passphrase>abcdef</jdeb.passphrase>
-                </properties>
-            </profile>
-        </profiles>
-        <activeProfiles>
-            <activeProfile>jdeb-signing</activeProfile>
-        </activeProfiles>
-    </settings>
-
+```xml
+  <settings>
+    <profiles>
+      <profile>
+        <id>jdeb-signing</id>
+        <properties>
+          <jdeb.keyring>/home/user/.gnupg/secring.gpg</jdeb.keyring>
+          <jdeb.key>8306FE21</jdeb.key>
+          <jdeb.passphrase>abcdef</jdeb.passphrase>
+        </properties>
+      </profile>
+    </profiles>
+    <activeProfiles>
+      <activeProfile>jdeb-signing</activeProfile>
+    </activeProfiles>
+  </settings>
+```
 keyring, key and passphrase can then be omitted from the POM entirely.

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,12 @@
             <version>3.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <reporting>
         <excludeDefaults>true</excludeDefaults>

--- a/src/main/java/org/vafer/jdeb/maven/Data.java
+++ b/src/main/java/org/vafer/jdeb/maven/Data.java
@@ -29,6 +29,7 @@ import org.vafer.jdeb.DataProducer;
 import org.vafer.jdeb.producers.DataProducerArchive;
 import org.vafer.jdeb.producers.DataProducerDirectory;
 import org.vafer.jdeb.producers.DataProducerFile;
+import org.vafer.jdeb.producers.DataProducerFiles;
 import org.vafer.jdeb.producers.DataProducerLink;
 import org.vafer.jdeb.producers.DataProducerPathTemplate;
 
@@ -155,7 +156,7 @@ public final class Data implements DataProducer {
 
         // link type
 
-        if ("link".equalsIgnoreCase(type)) {
+        if (typeIs("link")) {
             if (linkName == null) {
                 throw new RuntimeException("linkName is not set");
             }
@@ -169,12 +170,15 @@ public final class Data implements DataProducer {
 
         // template type
 
-        if ("template".equalsIgnoreCase(type)) {
-            if (paths == null || paths.length == 0) {
-                throw new RuntimeException("paths is not set");
-            }
-
+        if (typeIs("template")) {
+            checkPaths();
             new DataProducerPathTemplate(paths, includePatterns, excludePatterns, mappers).produce(pReceiver);
+            return;
+        }
+
+        if (typeIs("files")) {
+            checkPaths();
+            new DataProducerFiles(paths, dst, mappers).produce(pReceiver);
             return;
         }
 
@@ -188,17 +192,17 @@ public final class Data implements DataProducer {
             }
         }
 
-        if ("file".equalsIgnoreCase(type)) {
+        if (typeIs("file")) {
             new DataProducerFile(src, dst, includePatterns, excludePatterns, mappers).produce(pReceiver);
             return;
         }
 
-        if ("archive".equalsIgnoreCase(type)) {
+        if (typeIs("archive")) {
             new DataProducerArchive(src, includePatterns, excludePatterns, mappers).produce(pReceiver);
             return;
         }
 
-        if ("directory".equalsIgnoreCase(type)) {
+        if (typeIs("directory")) {
             new DataProducerDirectory(src, includePatterns, excludePatterns, mappers).produce(pReceiver);
             return;
         }
@@ -206,4 +210,13 @@ public final class Data implements DataProducer {
         throw new IOException("Unknown type '" + type + "' (file|directory|archive|template|link) for " + src);
     }
 
+    private boolean typeIs( final String type ) {
+        return type.equalsIgnoreCase(this.type);
+    }
+
+    private void checkPaths() {
+        if (paths == null || paths.length == 0) {
+            throw new RuntimeException("paths parameter is not set");
+        }
+    }
 }

--- a/src/main/java/org/vafer/jdeb/producers/AbstractDataProducer.java
+++ b/src/main/java/org/vafer/jdeb/producers/AbstractDataProducer.java
@@ -17,8 +17,13 @@ package org.vafer.jdeb.producers;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.tools.ant.types.selectors.SelectorUtils;
+import org.vafer.jdeb.DataConsumer;
 import org.vafer.jdeb.DataProducer;
 import org.vafer.jdeb.mapping.Mapper;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 
 /**
  * Base Producer class providing including/excluding.
@@ -65,6 +70,23 @@ public abstract class AbstractDataProducer implements DataProducer {
             }
         }
         return false;
+    }
+
+    public void produceDir( final DataConsumer consumer,
+                            final String dirname ) throws IOException {
+        TarArchiveEntry entry = Producers.defaultDirEntryWithName(dirname);
+        entry = map(entry);
+        entry.setSize(0);
+        Producers.produceDirEntry(consumer, entry);
+    }
+
+    public void produceFile( final DataConsumer consumer,
+                             final File file,
+                             final String entryName ) throws IOException {
+        TarArchiveEntry entry = Producers.defaultFileEntryWithName(entryName);
+        entry.setSize(file.length());
+        entry = map(entry);
+        Producers.produceInputStreamWithEntry(consumer, new FileInputStream(file), entry);
     }
 
     public TarArchiveEntry map( final TarArchiveEntry pEntry ) {

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerDirectory.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerDirectory.java
@@ -72,18 +72,7 @@ public final class DataProducerDirectory extends AbstractDataProducer implements
                 dirname += "/";
             }
 
-            TarArchiveEntry entry = new TarArchiveEntry(dirname, true);
-            entry.setUserId(0);
-            entry.setUserName("root");
-            entry.setGroupId(0);
-            entry.setGroupName("root");
-            entry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
-
-            entry = map(entry);
-
-            entry.setSize(0);
-
-            pReceiver.onEachDir(entry.getName(), entry.getLinkName(), entry.getUserName(), entry.getUserId(), entry.getGroupName(), entry.getGroupId(), entry.getMode(), entry.getSize());
+            produceDir(pReceiver, dirname);
         }
 
 
@@ -99,23 +88,7 @@ public final class DataProducerDirectory extends AbstractDataProducer implements
                 continue;
             }
 
-            TarArchiveEntry entry = new TarArchiveEntry(filename, true);
-            entry.setUserId(0);
-            entry.setUserName("root");
-            entry.setGroupId(0);
-            entry.setGroupName("root");
-            entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
-
-            entry = map(entry);
-
-            entry.setSize(file.length());
-
-            final InputStream inputStream = new FileInputStream(file);
-            try {
-                pReceiver.onEachFile(inputStream, entry.getName(), entry.getLinkName(), entry.getUserName(), entry.getUserId(), entry.getGroupName(), entry.getGroupId(), entry.getMode(), entry.getSize());
-            } finally {
-                inputStream.close();
-            }
+            produceFile(pReceiver, file, filename);
         }
     }
 

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerFile.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerFile.java
@@ -51,23 +51,13 @@ public final class DataProducerFile extends AbstractDataProducer implements Data
             fileName = file.getName();
         }
 
-        TarArchiveEntry entry = new TarArchiveEntry(fileName, true);
-        entry.setUserId(0);
-        entry.setUserName("root");
-        entry.setGroupId(0);
-        entry.setGroupName("root");
-        entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+        TarArchiveEntry entry = Producers.defaultFileEntryWithName(fileName);
 
         entry = map(entry);
 
         entry.setSize(file.length());
 
-        final InputStream inputStream = new FileInputStream(file);
-        try {
-            pReceiver.onEachFile(inputStream, entry.getName(), entry.getLinkName(), entry.getUserName(), entry.getUserId(), entry.getGroupName(), entry.getGroupId(), entry.getMode(), entry.getSize());
-        } finally {
-            inputStream.close();
-        }
+        Producers.produceInputStreamWithEntry(pReceiver, new FileInputStream(file), entry);
     }
 
 }

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
@@ -42,10 +42,10 @@ public final class DataProducerFileSet implements DataProducer {
     }
 
     public void produce( final DataConsumer pReceiver ) throws IOException {
-        String user = "root";
-        int uid = 0;
-        String group = "root";
-        int gid = 0;
+        String user = Producers.ROOT_NAME;
+        int uid = Producers.ROOT_UID;
+        String group = Producers.ROOT_NAME;
+        int gid = Producers.ROOT_UID;
         int filemode = TarEntry.DEFAULT_FILE_MODE;
         int dirmode = TarEntry.DEFAULT_DIR_MODE;
         String prefix = "";

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerFiles.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerFiles.java
@@ -1,0 +1,43 @@
+package org.vafer.jdeb.producers;
+
+import org.vafer.jdeb.DataConsumer;
+import org.vafer.jdeb.mapping.Mapper;
+import org.vafer.jdeb.utils.Utils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Data producer that places multiple files into a single
+ * destination directory.
+ *
+ * @author Roman Kashitsyn
+ */
+public class DataProducerFiles extends AbstractDataProducer {
+
+    private final String[] files;
+    private final String destDir;
+
+    public DataProducerFiles( final String[] files,
+                              final String destDir,
+                              final Mapper[] mappers ) {
+        super(null, null, mappers);
+        this.files = files;
+        this.destDir = destDir;
+    }
+
+    @Override
+    public void produce( DataConsumer receiver ) throws IOException {
+        boolean hasDestDir = !Utils.isNullOrEmpty(destDir);
+
+        for (String fileName : files) {
+            File f = new File(fileName);
+
+            if (hasDestDir) {
+                fileName = Utils.movePath(fileName, destDir);
+            }
+
+            produceFile(receiver, f, fileName);
+        }
+    }
+}

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerLink.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerLink.java
@@ -45,10 +45,10 @@ public final class DataProducerLink extends AbstractDataProducer implements Data
         TarArchiveEntry entry = new TarArchiveEntry(path, symlink ? TarArchiveEntry.LF_SYMLINK : TarArchiveEntry.LF_LINK);
         entry.setLinkName(linkName);
 
-        entry.setUserId(0);
-        entry.setUserName("root");
-        entry.setGroupId(0);
-        entry.setGroupName("root");
+        entry.setUserId(Producers.ROOT_UID);
+        entry.setUserName(Producers.ROOT_NAME);
+        entry.setGroupId(Producers.ROOT_UID);
+        entry.setGroupName(Producers.ROOT_NAME);
         entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
 
         entry = map(entry);

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerPathTemplate.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerPathTemplate.java
@@ -33,18 +33,7 @@ public class DataProducerPathTemplate extends AbstractDataProducer implements Da
 
     public void produce( DataConsumer pReceiver ) throws IOException {
         for (String literalPath : literalPaths) {
-            TarArchiveEntry entry = new TarArchiveEntry(literalPath, true);
-            entry.setUserId(0);
-            entry.setUserName("root");
-            entry.setGroupId(0);
-            entry.setGroupName("root");
-            entry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
-
-            entry = map(entry);
-
-            entry.setSize(0);
-
-            pReceiver.onEachDir(entry.getName(), entry.getLinkName(), entry.getUserName(), entry.getUserId(), entry.getGroupName(), entry.getGroupId(), entry.getMode(), entry.getSize());
+            produceDir(pReceiver, literalPath);
         }
     }
 

--- a/src/main/java/org/vafer/jdeb/producers/Producers.java
+++ b/src/main/java/org/vafer/jdeb/producers/Producers.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2013 The jdeb developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.vafer.jdeb.producers;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+
+import org.apache.commons.io.IOUtils;
+import org.vafer.jdeb.DataConsumer;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Package-private utility class with common producers functionality.
+ *
+ * @author Roman Kashitsyn <roman.kashitsyn@gmail.com>
+ */
+class Producers {
+
+    final static int ROOT_UID = 0;
+    final static String ROOT_NAME = "root";
+
+    private Producers() {}
+
+
+    /**
+     * Creates a tar file entry with defaults parameters.
+     * @param entryName the entry name
+     * @return file entry with reasonable defaults
+     */
+    static TarArchiveEntry defaultFileEntryWithName( final String entryName ) {
+        TarArchiveEntry entry = new TarArchiveEntry(entryName, true);
+        entry.setUserId(ROOT_UID);
+        entry.setUserName(ROOT_NAME);
+        entry.setGroupId(ROOT_UID);
+        entry.setGroupName(ROOT_NAME);
+        entry.setMode(TarArchiveEntry.DEFAULT_FILE_MODE);
+        return entry;
+    }
+
+    /**
+     * Creates a tar directory entry with defaults parameters.
+     * @param dirName the directory name
+     * @return dir entry with reasonable defaults
+     */
+    static TarArchiveEntry defaultDirEntryWithName( final String dirName ) {
+        TarArchiveEntry entry = new TarArchiveEntry(dirName, true);
+        entry.setUserId(ROOT_UID);
+        entry.setUserName(ROOT_NAME);
+        entry.setGroupId(ROOT_UID);
+        entry.setGroupName(ROOT_NAME);
+        entry.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
+        return entry;
+    }
+
+    /**
+     * Forwards tar archive entry entry to a consumer.
+     * @param consumer the consumer
+     * @param entry the entry to pass
+     * @throws IOException
+     */
+    static void produceDirEntry( final DataConsumer consumer,
+                                 final TarArchiveEntry entry ) throws IOException {
+        consumer.onEachDir(
+                entry.getName(),
+                entry.getLinkName(),
+                entry.getUserName(),
+                entry.getUserId(),
+                entry.getGroupName(),
+                entry.getGroupId(),
+                entry.getMode(),
+                entry.getSize()
+        );
+    }
+
+
+    /**
+     * Feeds input stream to data consumer using metadata from tar entry.
+     * @param consumer the consumer
+     * @param inputStream the stream to feed
+     * @param entry the entry to use for metadata
+     * @throws IOException on consume error
+     */
+    static void produceInputStreamWithEntry( final DataConsumer consumer,
+                                             final InputStream inputStream,
+                                             final TarArchiveEntry entry ) throws IOException {
+        try {
+            consumer.onEachFile(inputStream,
+                    entry.getName(),
+                    entry.getLinkName(),
+                    entry.getUserName(),
+                    entry.getUserId(),
+                    entry.getGroupName(),
+                    entry.getGroupId(),
+                    entry.getMode(),
+                    entry.getSize()
+            );
+        } finally {
+            IOUtils.closeQuietly(inputStream);
+        }
+    }
+
+}

--- a/src/main/java/org/vafer/jdeb/utils/Utils.java
+++ b/src/main/java/org/vafer/jdeb/utils/Utils.java
@@ -207,6 +207,18 @@ public final class Utils {
     }
 
     /**
+     * Construct new path by replacing file directory part. No
+     * files are actually modified.
+     * @param file path to move
+     * @param target new path directory
+     */
+    public static String movePath( final String file,
+                                   final String target ) {
+        final String name = new File(file).getName();
+        return target.endsWith("/") ? target + name : target + '/' + name;
+    }
+
+    /**
      * Extracts value from map if given value is null.
      * @param value current value
      * @param props properties to extract value from
@@ -327,5 +339,12 @@ public final class Utils {
             first = false;
         }
         return builder.toString();
+    }
+
+    /**
+     * Returns true if string is null or empty.
+     */
+    public static boolean isNullOrEmpty(final String str) {
+        return str == null || str.length() == 0;
     }
 }

--- a/src/test/java/org/vafer/jdeb/producers/DataProducerFilesTestCase.java
+++ b/src/test/java/org/vafer/jdeb/producers/DataProducerFilesTestCase.java
@@ -1,0 +1,87 @@
+package org.vafer.jdeb.producers;
+
+import junit.framework.TestCase;
+import org.vafer.jdeb.DataConsumer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link org.vafer.jdeb.producers.DataProducerFiles}.
+ *
+ * @author Roman Kashitsyn
+ */
+public class DataProducerFilesTestCase extends TestCase {
+    File file1;
+    File file2;
+
+    public void setUp() throws Exception {
+        file1 = File.createTempFile(getClass().getSimpleName() + ".1", "txt");
+        file2 = File.createTempFile(getClass().getSimpleName() + ".2", "txt");
+    }
+
+    public void tearDown() throws Exception {
+        file1.delete();
+        file2.delete();
+    }
+
+    public void testProducesMultiplePaths() throws IOException {
+        DataConsumer consumer = mock(DataConsumer.class);
+        new DataProducerFiles(
+                new String[]{
+                        file1.getAbsolutePath(),
+                        file2.getAbsolutePath()
+                },
+                "/usr/include",
+                null
+        ).produce(consumer);
+
+        for (File f : Arrays.asList(file1, file2)) {
+            verify(consumer).onEachFile(
+                    any(FileInputStream.class),
+                    eq("/usr/include/" + f.getName()),
+                    any(String.class),
+                    eq("root"),
+                    eq(0),
+                    eq("root"),
+                    eq(0),
+                    anyInt(),
+                    eq(f.length())
+            );
+        }
+    }
+
+    public void testProducesMultiplePathsNoDestination() throws IOException {
+        DataConsumer consumer = mock(DataConsumer.class);
+        new DataProducerFiles(
+                new String[]{
+                        file1.getAbsolutePath(),
+                        file2.getAbsolutePath()
+                },
+                null,
+                null
+        ).produce(consumer);
+
+        for (File f : Arrays.asList(file1, file2)) {
+            verify(consumer).onEachFile(
+                    any(FileInputStream.class),
+                    eq(f.getAbsolutePath()),
+                    any(String.class),
+                    eq("root"),
+                    eq(0),
+                    eq("root"),
+                    eq(0),
+                    anyInt(),
+                    eq(f.length())
+            );
+        }
+    }
+}

--- a/src/test/java/org/vafer/jdeb/utils/UtilsTestCase.java
+++ b/src/test/java/org/vafer/jdeb/utils/UtilsTestCase.java
@@ -99,4 +99,12 @@ public class UtilsTestCase extends TestCase {
         assertEquals("should match", "1.0~Beta+4", Utils.convertToDebianVersion("1.0.Beta-4", cal.getTime()));
         assertEquals("should match", "1.0~rc7", Utils.convertToDebianVersion("1.0rc7", cal.getTime()));
     }
+
+    public void testMovePath() {
+        assertEquals("/usr/share/file.txt", Utils.movePath("file.txt", "/usr/share"));
+        assertEquals("/usr/share/file.txt", Utils.movePath("file.txt", "/usr/share/"));
+        assertEquals("/usr/share/noext", Utils.movePath("noext", "/usr/share/"));
+        assertEquals("/usr/share/file.txt", Utils.movePath("/home/user/file.txt", "/usr/share"));
+        assertEquals("/usr/share/file.txt", Utils.movePath("../relative/file.txt", "/usr/share/"));
+    }
 }


### PR DESCRIPTION
Now it's possible to declare multiple files inside the
`<data>` section. Example:

```
<data>
  <type>files</type>
  <paths>
    <path>Readme.txt</path>
    <path>Changes.txt</path>
  </paths>
  <dst>/usr/share/myapp</dst>
</data>
```

Note that the `dst` element is optional and used as directory if
present. Mapper could be used instead.

The mockito library is added to `pom.xml` to simplify unit testing.
