### PR TITLE
Add support for path templates in Ant task

### DIFF
--- a/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
+++ b/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
@@ -142,9 +142,9 @@ public class DebAntTask extends MatchingTask {
             if (dataProducer instanceof Data) {
                 Data data = (Data) dataProducer;
                 if (data.getType() == null) {
-                    throw new BuildException("The type of the data element wasn't specified (expected 'file', 'directory' or 'archive')");
-                } else if (!Arrays.asList("file", "directory", "archive").contains(data.getType().toLowerCase())) {
-                    throw new BuildException("The type '" + data.getType() + "' of the data element is unknown (expected 'file', 'directory' or 'archive')");
+                    throw new BuildException("The type of the data element wasn't specified (expected 'file', 'directory', 'archive' or 'template')");
+                } else if (!Arrays.asList("file", "directory", "archive", "template").contains(data.getType().toLowerCase())) {
+                    throw new BuildException("The type '" + data.getType() + "' of the data element is unknown (expected 'file', 'directory', 'archive' or 'template')");
                 }
                 if (data.getConffile() != null && data.getConffile()) {
                     conffilesProducers.add(dataProducer);

--- a/src/test/java/org/vafer/jdeb/ant/DebAntTaskTestCase.java
+++ b/src/test/java/org/vafer/jdeb/ant/DebAntTaskTestCase.java
@@ -323,4 +323,19 @@ public final class DebAntTaskTestCase extends TestCase {
 
         assertTrue("package not build", new File("target/test-classes/test.deb").exists());
     }
+
+    public void testPackageWithTemplate() {
+        project.executeTarget("with-template");
+
+        assertTrue("package not build", new File("target/test-classes/test.deb").exists());
+    }
+
+    public void testPackageWithTemplateMissingPaths() {
+        try {
+            project.executeTarget("with-missing-template");
+            fail("No exception thrown");
+        } catch (BuildException e) {
+            // expected
+        }
+    }
 }

--- a/src/test/resources/testbuild.xml
+++ b/src/test/resources/testbuild.xml
@@ -125,4 +125,22 @@
     </deb>
   </target>
 
+  <target name="with-template">
+    <deb destfile="test.deb" control="org/vafer/jdeb/deb/control">
+      <data type="template" paths="
+          /var/log/foo,
+          /var/cache/foo
+        ">
+        <mapper type="perm" filemode="755"/>
+      </data>
+    </deb>
+  </target>
+
+  <target name="with-missing-template">
+    <deb destfile="test.deb" control="org/vafer/jdeb/deb/control">
+      <data type="template">
+        <mapper type="perm" filemode="755"/>
+      </data>
+    </deb>
+  </target>
 </project>


### PR DESCRIPTION
This change makes it possible to use:

```
<data type='template' paths='/var/log/foo, /var/cache/foo' />
```

in Ant. The 'paths' argument is a comma-separated list of directories to
create in the deb file.
