### PR TITLE
Upgrade to bouncycastle 1.51

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpg-jdk15on</artifactId>
-            <version>1.50</version>
+            <version>1.51</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/vafer/jdeb/utils/PGPSignatureOutputStream.java
+++ b/src/main/java/org/vafer/jdeb/utils/PGPSignatureOutputStream.java
@@ -3,7 +3,6 @@ package org.vafer.jdeb.utils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.security.SignatureException;
 
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.openpgp.PGPException;
@@ -26,34 +25,22 @@ public class PGPSignatureOutputStream extends OutputStream {
     }
 
     public void write( int b ) throws IOException {
-        try {
-            signatureGenerator.update(new byte[] { (byte)b });
-        } catch(SignatureException e) {
-            throw new IOException(e);
-        }
+        signatureGenerator.update(new byte[] { (byte)b });
     }
 
     public void write( byte[] b ) throws IOException {
-        try {
-            signatureGenerator.update(b);
-        } catch(SignatureException e) {
-            throw new IOException(e);
-        }
+        signatureGenerator.update(b);
     }
 
     public void write( byte[] b, int off, int len ) throws IOException {
-        try {
-            signatureGenerator.update(b, off, len);
-        } catch(SignatureException e) {
-            throw new IOException(e);
-        }
+        signatureGenerator.update(b, off, len);
     }
     
-    public PGPSignature generateSignature() throws SignatureException, PGPException {
+    public PGPSignature generateSignature() throws PGPException {
         return signatureGenerator.generate();
     }
     
-    public String generateASCIISignature() throws SignatureException, PGPException {
+    public String generateASCIISignature() throws PGPException {
         try {
             PGPSignature signature = generateSignature();
             ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/src/test/java/org/vafer/jdeb/signing/PGPSignerTestCase.java
+++ b/src/test/java/org/vafer/jdeb/signing/PGPSignerTestCase.java
@@ -41,7 +41,7 @@ public final class PGPSignerTestCase extends TestCase {
                 "\n" +
                 "TEST3\n" +
                 "-----BEGIN PGP SIGNATURE-----\n" +
-                "Version: BCPG v1.50\n" +
+                "Version: BCPG v1.51\n" +
                 "\n" +
                 "iEYEARECABAFAkax1rgJEHM9pIAuB02PAABIJgCghFmoCJCZ0CGiqgVLGGPd/Yh5\n" +
                 "FQQAnRVqvI2ij45JQSHYJBblZ0Vv2meN\n" +


### PR DESCRIPTION
This fixes the warning being printed out with 1.50

```
[WARNING] bcprov-jdk15on-1.50.jar, bcpg-jdk15on-1.50.jar define 3 overlappping classes: 
[WARNING]   - org.bouncycastle.apache.bzip2.CBZip2InputStream
[WARNING]   - org.bouncycastle.apache.bzip2.CRC
[WARNING]   - org.bouncycastle.apache.bzip2.BZip2Constants
[WARNING] maven-shade-plugin has detected that some .class files
[WARNING] are present in two or more JARs. When this happens, only
[WARNING] one single version of the class is copied in the uberjar.
[WARNING] Usually this is not harmful and you can skeep these
[WARNING] warnings, otherwise try to manually exclude artifacts
[WARNING] based on mvn dependency:tree -Ddetail=true and the above
[WARNING] output
[WARNING] See http://docs.codehaus.org/display/MAVENUSER/Shade+Plugin
```
