### PR TITLE
allow for Multi-Arch declaration

### DIFF
--- a/src/main/java/org/vafer/jdeb/debian/BinaryPackageControlFile.java
+++ b/src/main/java/org/vafer/jdeb/debian/BinaryPackageControlFile.java
@@ -48,7 +48,8 @@ public final class BinaryPackageControlFile extends ControlFile {
             new ControlField("Installed-Size"),
             new ControlField("Maintainer", true),
             new ControlField("Description", true, ControlField.Type.MULTILINE),
-            new ControlField("Homepage")
+            new ControlField("Homepage"),
+            new ControlField("Multi-Arch")
     };
 
     public BinaryPackageControlFile() {


### PR DESCRIPTION
This small fix allows one to specify the Multi-Arch field for mixed architecture support per
 per https://wiki.ubuntu.com/MultiarchSpec and https://wiki.debian.org/Multiarch/Implementation#line-61
