### PR TITLE
Fixes Issue #181

### DIFF
--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -16,6 +16,8 @@
 
 package org.vafer.jdeb.maven;
 
+import static org.vafer.jdeb.utils.Utils.lookupIfEmpty;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -41,6 +43,7 @@ import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.settings.Profile;
 import org.apache.maven.settings.Settings;
 import org.apache.tools.tar.TarEntry;
+import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 import org.vafer.jdeb.Console;
@@ -51,8 +54,6 @@ import org.vafer.jdeb.PackagingException;
 import org.vafer.jdeb.utils.MapVariableResolver;
 import org.vafer.jdeb.utils.Utils;
 import org.vafer.jdeb.utils.VariableResolver;
-
-import static org.vafer.jdeb.utils.Utils.lookupIfEmpty;
 
 /**
  * Creates Debian package
@@ -259,7 +260,7 @@ public class DebMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "false")
     private boolean skipSubmodules;
-
+    
     /**
      * @deprecated
      */
@@ -316,6 +317,9 @@ public class DebMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "${settings}")
     private Settings settings;
+    
+    @Parameter(defaultValue = "")
+    private String propertyPrefix;
 
     /* end of parameters */
     
@@ -545,6 +549,13 @@ public class DebMojo extends AbstractMojo {
             getLog().error("Failed to create debian package " + debFile, e);
             throw new MojoExecutionException("Failed to create debian package " + debFile, e);
         }
+        
+        if (!StringUtils.isBlank(propertyPrefix)) {
+          project.getProperties().put(propertyPrefix+"deb", debFile.getAbsolutePath());
+          project.getProperties().put(propertyPrefix+"changes", changesOutFile.getAbsolutePath());
+          project.getProperties().put(propertyPrefix+"changes.txt", changesSaveFile.getAbsolutePath());
+        }
+        
     }
 
     /**

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -551,6 +551,7 @@ public class DebMojo extends AbstractMojo {
         }
         
         if (!StringUtils.isBlank(propertyPrefix)) {
+          project.getProperties().put(propertyPrefix+"version", getProjectVersion() );
           project.getProperties().put(propertyPrefix+"deb", debFile.getAbsolutePath());
           project.getProperties().put(propertyPrefix+"deb.name", debFile.getName());
           project.getProperties().put(propertyPrefix+"changes", changesOutFile.getAbsolutePath());

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -552,8 +552,11 @@ public class DebMojo extends AbstractMojo {
         
         if (!StringUtils.isBlank(propertyPrefix)) {
           project.getProperties().put(propertyPrefix+"deb", debFile.getAbsolutePath());
+          project.getProperties().put(propertyPrefix+"deb.name", debFile.getName());
           project.getProperties().put(propertyPrefix+"changes", changesOutFile.getAbsolutePath());
+          project.getProperties().put(propertyPrefix+"changes.name", changesOutFile.getName());
           project.getProperties().put(propertyPrefix+"changes.txt", changesSaveFile.getAbsolutePath());
+          project.getProperties().put(propertyPrefix+"changes.txt.name", changesSaveFile.getName());
         }
         
     }


### PR DESCRIPTION
This fixes issue #181. This adds a new property called "propertyPrefix" which when set will populate 7 variables with the deb name, path, changes name, path and version number. This is needed for other plugins to be able to access these files (for example wagon, etc..)