### PR TITLE
Bump version in Maven documentation to 1.4

### DIFF
--- a/docs/maven.md
+++ b/docs/maven.md
@@ -9,7 +9,7 @@ the plugin to your POM like this
       <plugin>
         <artifactId>jdeb</artifactId>
         <groupId>org.vafer</groupId>
-        <version>1.3</version>
+        <version>1.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -47,7 +47,7 @@ Or if you want to build a custom deb file
       <extension>
         <groupId>org.vafer</groupId>
         <artifactId>jdeb</artifactId>
-        <version>1.3</version>
+        <version>1.4</version>
       </extension>
     </extensions>
     <pluginManagement>
@@ -184,7 +184,7 @@ include a directory, a tarball, and a file in your deb package and then sign it 
       <plugin>
         <artifactId>jdeb</artifactId>
         <groupId>org.vafer</groupId>
-        <version>1.3</version>
+        <version>1.4</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
I followed the Maven documentation today and noticed that 1.3 is still present instead of 1.4. I followed the documentation using 1.4 and everything worked out fine. Hope this little contribution helps!