### PR TITLE
Small package signing customization

### DIFF
--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -26,7 +26,6 @@ import org.bouncycastle.crypto.digests.MD5Digest;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPSignature;
 import org.bouncycastle.openpgp.PGPSignatureGenerator;
-import org.bouncycastle.openpgp.PGPUtil;
 import org.bouncycastle.openpgp.operator.bc.BcPGPContentSignerBuilder;
 import org.bouncycastle.util.encoders.Hex;
 import org.vafer.jdeb.changes.ChangeSet;
@@ -39,13 +38,22 @@ import org.vafer.jdeb.utils.PGPSignatureOutputStream;
 import org.vafer.jdeb.utils.Utils;
 import org.vafer.jdeb.utils.VariableResolver;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * A generic class for creating Debian archives. Even supports signed changes

--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -16,28 +16,12 @@
 
 package org.vafer.jdeb;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.Security;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-
 import org.apache.commons.compress.archivers.ar.ArArchiveEntry;
 import org.apache.commons.compress.archivers.ar.ArArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.crypto.digests.MD5Digest;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPSignature;
@@ -54,6 +38,14 @@ import org.vafer.jdeb.signing.PGPSigner;
 import org.vafer.jdeb.utils.PGPSignatureOutputStream;
 import org.vafer.jdeb.utils.Utils;
 import org.vafer.jdeb.utils.VariableResolver;
+
+import java.io.*;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 /**
  * A generic class for creating Debian archives. Even supports signed changes
@@ -109,6 +101,9 @@ public class DebMaker {
     /** Whether to sign the package that is created */
     private boolean signPackage;
 
+    /** Whether to sign the changes file that is created */
+    private boolean signChanges;
+
     /** Defines which utility is used to verify the signed package */
     private String signMethod;
 
@@ -122,7 +117,7 @@ public class DebMaker {
     private final Collection<DataProducer> dataProducers = new ArrayList<DataProducer>();
 
     private final Collection<DataProducer> conffilesProducers = new ArrayList<DataProducer>();
-
+    private String digest = "SHA1";
 
     public DebMaker(Console console, Collection<DataProducer> dataProducers, Collection<DataProducer> conffileProducers) {
         this.console = console;
@@ -180,6 +175,10 @@ public class DebMaker {
         this.signPackage = signPackage;
     }
 
+    public void setSignChanges(boolean signChanges) {
+        this.signChanges = signChanges;
+    }
+
     public void setSignMethod(String signMethod) {
         this.signMethod = signMethod;
     }
@@ -210,6 +209,14 @@ public class DebMaker {
 
     private boolean isWritableFile(File file) {
         return !file.exists() || file.isFile() && file.canWrite();
+    }
+
+    public String getDigest() {
+        return digest;
+    }
+
+    public void setDigest(String digest) {
+        this.digest = digest;
     }
 
     /**
@@ -247,6 +254,30 @@ public class DebMaker {
         if (deb == null) {
             throw new PackagingException("You need to specify where the deb file is supposed to be created.");
         }
+
+        getDigestCode(digest);
+    }
+
+    static int getDigestCode(String digestName) throws PackagingException {
+        if ("SHA1".equals(digestName)) {
+            return HashAlgorithmTags.SHA1;
+        } else if ("MD2".equals(digestName)) {
+            return HashAlgorithmTags.MD2;
+        } else if ("MD5".equals(digestName)) {
+            return HashAlgorithmTags.MD5;
+        } else if ("RIPEMD160".equals(digestName)) {
+            return HashAlgorithmTags.RIPEMD160;
+        } else if ("SHA256".equals(digestName)) {
+            return HashAlgorithmTags.SHA256;
+        } else if ("SHA384".equals(digestName)) {
+            return HashAlgorithmTags.SHA384;
+        } else if ("SHA512".equals(digestName)) {
+            return HashAlgorithmTags.SHA512;
+        } else if ("SHA224".equals(digestName)) {
+            return HashAlgorithmTags.SHA224;
+        } else {
+            throw new PackagingException("unknown hash algorithm tag in digestName: " + digestName);
+        }
     }
 
     public void makeDeb() throws PackagingException {
@@ -277,14 +308,12 @@ public class DebMaker {
                 FileInputStream keyRingInput = new FileInputStream(keyring);
                 PGPSigner signer = null;
                 try {
-                    signer = new PGPSigner(new FileInputStream(keyring), key, passphrase);
+                    signer = new PGPSigner(new FileInputStream(keyring), key, passphrase, getDigestCode(digest));
                 } finally {
                     keyRingInput.close();
                 }
 
-                int digest = PGPUtil.SHA1;
-
-                PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(signer.getSecretKey().getPublicKey().getAlgorithm(), digest));
+                PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(signer.getSecretKey().getPublicKey().getAlgorithm(), getDigestCode(digest)));
                 signatureGenerator.init(PGPSignature.BINARY_DOCUMENT, signer.getPrivateKey());
 
                 packageControlFile = createSignedDeb(Compression.toEnum(compression), signatureGenerator, signer);
@@ -336,9 +365,10 @@ public class DebMaker {
             ChangesFileBuilder builder = new ChangesFileBuilder();
             ChangesFile changesFile = builder.createChanges(packageControlFile, deb, changesProvider);
 
-            if (keyring != null && key != null && passphrase != null) {
+            //(signChanges || signPackage) - for backward compatibility. signPackage is signing both changes and deb.
+            if ((signChanges || signPackage) && keyring != null && key != null && passphrase != null) {
                 console.info("Signing the changes file with the key " + key);
-                PGPSigner signer = new PGPSigner(new FileInputStream(keyring), key, passphrase);
+                PGPSigner signer = new PGPSigner(new FileInputStream(keyring), key, passphrase, getDigestCode(digest));
                 signer.clearSign(changesFile.toString(), out);
             } else {
                 out.write(changesFile.toString().getBytes("UTF-8"));
@@ -593,7 +623,7 @@ public class DebMaker {
         try
         {
             //prepare the input
-            MessageDigest hash = MessageDigest.getInstance("SHA1");
+            MessageDigest hash = MessageDigest.getInstance(digest);
             hash.update(input);
 
             //proceed ....

--- a/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
+++ b/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
@@ -64,6 +64,13 @@ public class DebAntTask extends MatchingTask {
     /** The compression method used for the data file (none, gzip, bzip2 or xz) */
     private String compression = "gzip";
 
+    /**
+     * The digest algorithm to use.
+     *
+     * @see org.bouncycastle.bcpg.HashAlgorithmTags
+     */
+    private String digest = "SHA1";
+
     /** Trigger the verbose mode detailing all operations */
     private boolean verbose;
 
@@ -129,6 +136,10 @@ public class DebAntTask extends MatchingTask {
         links.add(link);
     }
 
+    public void setDigest(String digest) {
+        this.digest = digest;
+    }
+
     @Override
     public void execute() {
         // add the data producers for the links
@@ -163,6 +174,7 @@ public class DebAntTask extends MatchingTask {
         debMaker.setKey(key);
         debMaker.setPassphrase(passphrase);
         debMaker.setCompression(compression);
+        debMaker.setDigest(digest);
         
         try {
             debMaker.validate();

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -167,6 +167,14 @@ public class DebMojo extends AbstractMojo {
     private String classifier;
 
     /**
+     * The digest algorithm to use.
+     *
+     * @see org.bouncycastle.bcpg.HashAlgorithmTags
+     */
+    @Parameter(defaultValue = "SHA1")
+    private String digest;
+
+    /**
      * "data" entries used to determine which files should be added to this deb.
      * The "data" entries may specify a tarball (tar.gz, tar.bz2, tgz), a
      * directory, or a normal file. An entry would look something like this in
@@ -277,7 +285,13 @@ public class DebMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "false")
     private boolean signPackage;
-    
+
+    /**
+     * If signChanges is true then changes file will be signed.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean signChanges;
+
     /**
      * Defines which utility is used to verify the signed package
      */
@@ -544,11 +558,13 @@ public class DebMojo extends AbstractMojo {
             debMaker.setKey(key);
             debMaker.setPassphrase(passphrase);
             debMaker.setSignPackage(signPackage);
+            debMaker.setSignChanges(signChanges);
             debMaker.setSignMethod(signMethod);
             debMaker.setSignRole(signRole);
             debMaker.setResolver(resolver);
             debMaker.setOpenReplaceToken(openReplaceToken);
             debMaker.setCloseReplaceToken(closeReplaceToken);
+            debMaker.setDigest(digest);
             debMaker.validate();
             debMaker.makeDeb();
 
@@ -584,7 +600,7 @@ public class DebMojo extends AbstractMojo {
      * and global settings.
      */
     private void initializeSignProperties() {
-        if (!signPackage) {
+        if (!signPackage && !signChanges) {
             return;
         }
 

--- a/src/main/java/org/vafer/jdeb/signing/PGPSigner.java
+++ b/src/main/java/org/vafer/jdeb/signing/PGPSigner.java
@@ -49,14 +49,16 @@ public class PGPSigner {
 
     private PGPSecretKey secretKey;
     private PGPPrivateKey privateKey;
+    private int digest;
 
-    public PGPSigner(InputStream keyring, String keyId, String passphrase) throws IOException, PGPException {
+    public PGPSigner(InputStream keyring, String keyId, String passphrase, int digest) throws IOException, PGPException {
         secretKey = getSecretKey(keyring, keyId);
         if(secretKey == null)
         {
             throw new PGPException(String.format("Specified key %s does not exist in key ring %s", keyId, keyring));
         }
         privateKey = secretKey.extractPrivateKey(new BcPBESecretKeyDecryptorBuilder(new BcPGPDigestCalculatorProvider()).build(passphrase.toCharArray()));
+        this.digest = digest;
     }
 
     /**
@@ -76,8 +78,7 @@ public class PGPSigner {
      * @param output     the output destination of the signature
      */
     public void clearSign(InputStream input, OutputStream output) throws IOException, PGPException, GeneralSecurityException {
-        int digest = PGPUtil.SHA1;
-        
+
         PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(privateKey.getPublicKeyPacket().getAlgorithm(), digest));
         signatureGenerator.init(PGPSignature.CANONICAL_TEXT_DOCUMENT, privateKey);
         

--- a/src/test/java/org/vafer/jdeb/signing/DebMakerTestCase.java
+++ b/src/test/java/org/vafer/jdeb/signing/DebMakerTestCase.java
@@ -63,7 +63,7 @@ public class DebMakerTestCase extends TestCase {
         };
 
         int digest = PGPUtil.SHA1;
-        PGPSigner signer = new PGPSigner(ring, "2E074D8F", "test");
+        PGPSigner signer = new PGPSigner(ring, "2E074D8F", "test", PGPUtil.SHA1);
         PGPSignatureGenerator signatureGenerator = new PGPSignatureGenerator(new BcPGPContentSignerBuilder(signer.getSecretKey().getPublicKey().getAlgorithm(), digest));
         signatureGenerator.init(PGPSignature.BINARY_DOCUMENT, signer.getPrivateKey());
         

--- a/src/test/java/org/vafer/jdeb/signing/PGPSignerTestCase.java
+++ b/src/test/java/org/vafer/jdeb/signing/PGPSignerTestCase.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 
 import junit.framework.TestCase;
+import org.bouncycastle.openpgp.PGPUtil;
 
 public final class PGPSignerTestCase extends TestCase {
 
@@ -52,7 +53,7 @@ public final class PGPSignerTestCase extends TestCase {
 
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        PGPSigner signer = new PGPSigner(ring, "2E074D8F", "test");
+        PGPSigner signer = new PGPSigner(ring, "2E074D8F", "test", PGPUtil.SHA1);
         signer.clearSign(input, os);
 
         final byte[] output = fixCRLF(os.toByteArray());
@@ -66,11 +67,11 @@ public final class PGPSignerTestCase extends TestCase {
 
     public void testKeyLoading() throws Exception {
         InputStream ring = getClass().getClassLoader().getResourceAsStream("org/vafer/gpg/secring.gpg");
-        PGPSigner signer = new PGPSigner(ring, "2E074D8F", "test");
+        PGPSigner signer = new PGPSigner(ring, "2E074D8F", "test", PGPUtil.SHA1);
         assertEquals("correct key found", "733da4802e074d8f", String.format("%016x", signer.getSecretKey().getKeyID()));
 
         ring.reset();
-        signer = new PGPSigner(ring, "0C1FF47A", "test");
+        signer = new PGPSigner(ring, "0C1FF47A", "test", PGPUtil.SHA1);
         assertEquals("key with leading 0 found", "21970bb80c1ff47a", String.format("%016x", signer.getSecretKey().getKeyID()));
     }
 


### PR DESCRIPTION
Hi! Need some changes to use jdeb in corporate repo. Would be great if you could incorporate this. Looks like everything is backward compatible.

Changes:
1. Allow to sign only .changes file without signing .deb archive. Introduced new property signChanges in addition to signPackage.
2. Added property to allow custom digest algorithm. Need SHA256 instead of SHA1 for corporate repo
