### PR TITLE
#230 Expose settings for bigNumber/longFile modes on tar file

### DIFF
--- a/src/main/java/org/vafer/jdeb/DataBuilder.java
+++ b/src/main/java/org/vafer/jdeb/DataBuilder.java
@@ -78,21 +78,27 @@ class DataBuilder {
      * @param producers
      * @param output
      * @param checksums
-     * @param compression the compression method used for the data file
+     * @param options Options used to build the data file
      * @return
      * @throws java.security.NoSuchAlgorithmException
      * @throws java.io.IOException
      * @throws org.apache.commons.compress.compressors.CompressorException
      */
-    BigInteger buildData(Collection<DataProducer> producers, File output, final StringBuilder checksums, Compression compression) throws NoSuchAlgorithmException, IOException, CompressorException {
+    BigInteger buildData(Collection<DataProducer> producers, File output, final StringBuilder checksums, TarOptions options) throws NoSuchAlgorithmException, IOException, CompressorException {
 
         final File dir = output.getParentFile();
         if (dir != null && (!dir.exists() || !dir.isDirectory())) {
             throw new IOException("Cannot write data file at '" + output.getAbsolutePath() + "'");
         }
 
-        final TarArchiveOutputStream tarOutputStream = new TarArchiveOutputStream(compression.toCompressedOutputStream(new FileOutputStream(output)));
-        tarOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+        final TarArchiveOutputStream tarOutputStream = new TarArchiveOutputStream(
+            options.compression().toCompressedOutputStream(new FileOutputStream(output))
+        );
+        tarOutputStream.setLongFileMode(options.longFileMode());
+        tarOutputStream.setBigNumberMode(options.bigNumberMode());
+
+        System.out.println("##### longFileMode: " + options.longFileMode());
+        System.out.println("##### bigNumberMode: " + options.bigNumberMode());
 
         final MessageDigest digest = MessageDigest.getInstance("MD5");
 

--- a/src/main/java/org/vafer/jdeb/DataBuilder.java
+++ b/src/main/java/org/vafer/jdeb/DataBuilder.java
@@ -16,6 +16,14 @@
 
 package org.vafer.jdeb;
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
+import org.apache.commons.compress.archivers.zip.ZipEncoding;
+import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.vafer.jdeb.utils.Utils;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -28,14 +36,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.apache.commons.compress.archivers.tar.TarConstants;
-import org.apache.commons.compress.archivers.zip.ZipEncoding;
-import org.apache.commons.compress.archivers.zip.ZipEncodingHelper;
-import org.apache.commons.compress.compressors.CompressorException;
-import org.vafer.jdeb.utils.Utils;
 
 /**
  * Builds the data archive of the Debian package.
@@ -96,9 +96,6 @@ class DataBuilder {
         );
         tarOutputStream.setLongFileMode(options.longFileMode());
         tarOutputStream.setBigNumberMode(options.bigNumberMode());
-
-        System.out.println("##### longFileMode: " + options.longFileMode());
-        System.out.println("##### bigNumberMode: " + options.bigNumberMode());
 
         final MessageDigest digest = MessageDigest.getInstance("MD5");
 

--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -118,6 +118,12 @@ public class DebMaker {
     /** Defines the role to sign with */
     private String signRole;
 
+    /** Defines the longFileMode of the tar file that is built */
+    private String tarLongFileMode;
+
+    /** Defines the bigNumberMode of the tar file that is built */
+    private String tarBigNumberMode;
+
     private VariableResolver variableResolver;
     private String openReplaceToken;
     private String closeReplaceToken;
@@ -225,6 +231,14 @@ public class DebMaker {
 
     public void setDigest(String digest) {
         this.digest = digest;
+    }
+
+    public void setTarLongFileMode(String tarLongFileMode) {
+        this.tarLongFileMode = tarLongFileMode;
+    }
+
+    public void setTarBigNumberMode(String tarBigNumberMode) {
+        this.tarBigNumberMode = tarBigNumberMode;
     }
 
     /**
@@ -467,7 +481,11 @@ public class DebMaker {
             console.debug("Building data");
             DataBuilder dataBuilder = new DataBuilder(console);
             StringBuilder md5s = new StringBuilder();
-            BigInteger size = dataBuilder.buildData(dataProducers, tempData, md5s, compression);
+            TarOptions options = new TarOptions()
+                .compression(compression)
+                .longFileMode(tarLongFileMode)
+                .bigNumberMode(tarBigNumberMode);
+            BigInteger size = dataBuilder.buildData(dataProducers, tempData, md5s, options);
 
             console.info("Building conffiles");
             List<String> tempConffiles = populateConffiles(conffilesProducers);

--- a/src/main/java/org/vafer/jdeb/TarOptions.java
+++ b/src/main/java/org/vafer/jdeb/TarOptions.java
@@ -1,0 +1,54 @@
+package org.vafer.jdeb;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+
+public class TarOptions {
+
+    private Compression compression = Compression.GZIP;
+    private int longFileMode = TarArchiveOutputStream.LONGFILE_GNU;
+    private int bigNumberMode = TarArchiveOutputStream.BIGNUMBER_ERROR;
+
+    public TarOptions compression(Compression compression) {
+        this.compression = compression;
+
+        return this;
+    }
+
+    public TarOptions longFileMode(String input) {
+        if ("posix".equals(input)) {
+            longFileMode = TarArchiveOutputStream.LONGFILE_POSIX;
+        } else if ("error".equals(input)) {
+            longFileMode = TarArchiveOutputStream.LONGFILE_ERROR;
+        } else if ("truncate".equals(input)) {
+            longFileMode = TarArchiveOutputStream.LONGFILE_TRUNCATE;
+        } else {
+            longFileMode = TarArchiveOutputStream.LONGFILE_GNU;
+        }
+
+        return this;
+    }
+
+    public TarOptions bigNumberMode(String input) {
+        if ("posix".equals(input)) {
+            bigNumberMode = TarArchiveOutputStream.BIGNUMBER_POSIX;
+        } else if ("star".equals(input) || "gnu".equals(input)) {
+            bigNumberMode = TarArchiveOutputStream.BIGNUMBER_STAR;
+        } else {
+            bigNumberMode = TarArchiveOutputStream.LONGFILE_ERROR;
+        }
+
+        return this;
+    }
+
+    public int longFileMode() {
+        return longFileMode;
+    }
+
+    public int bigNumberMode() {
+        return bigNumberMode;
+    }
+
+    public Compression compression() {
+        return compression;
+    }
+}

--- a/src/main/java/org/vafer/jdeb/TarOptions.java
+++ b/src/main/java/org/vafer/jdeb/TarOptions.java
@@ -15,26 +15,26 @@ public class TarOptions {
     }
 
     public TarOptions longFileMode(String input) {
-        if ("posix".equals(input)) {
-            longFileMode = TarArchiveOutputStream.LONGFILE_POSIX;
+        if ("gnu".equals(input)) {
+            longFileMode = TarArchiveOutputStream.LONGFILE_GNU;
         } else if ("error".equals(input)) {
             longFileMode = TarArchiveOutputStream.LONGFILE_ERROR;
         } else if ("truncate".equals(input)) {
             longFileMode = TarArchiveOutputStream.LONGFILE_TRUNCATE;
         } else {
-            longFileMode = TarArchiveOutputStream.LONGFILE_GNU;
+            longFileMode = TarArchiveOutputStream.LONGFILE_POSIX;
         }
 
         return this;
     }
 
     public TarOptions bigNumberMode(String input) {
-        if ("posix".equals(input)) {
-            bigNumberMode = TarArchiveOutputStream.BIGNUMBER_POSIX;
+        if ("error".equals(input)) {
+            bigNumberMode = TarArchiveOutputStream.BIGNUMBER_ERROR;
         } else if ("star".equals(input) || "gnu".equals(input)) {
             bigNumberMode = TarArchiveOutputStream.BIGNUMBER_STAR;
         } else {
-            bigNumberMode = TarArchiveOutputStream.LONGFILE_ERROR;
+            bigNumberMode = TarArchiveOutputStream.BIGNUMBER_POSIX;
         }
 
         return this;

--- a/src/main/java/org/vafer/jdeb/TarOptions.java
+++ b/src/main/java/org/vafer/jdeb/TarOptions.java
@@ -5,8 +5,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 public class TarOptions {
 
     private Compression compression = Compression.GZIP;
-    private int longFileMode = TarArchiveOutputStream.LONGFILE_GNU;
-    private int bigNumberMode = TarArchiveOutputStream.BIGNUMBER_ERROR;
+    private int longFileMode = TarArchiveOutputStream.LONGFILE_POSIX;
+    private int bigNumberMode = TarArchiveOutputStream.BIGNUMBER_POSIX;
 
     public TarOptions compression(Compression compression) {
         this.compression = compression;

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -338,6 +338,20 @@ public class DebMojo extends AbstractMojo {
     @Parameter(defaultValue = "")
     private String propertyPrefix;
 
+    /**
+     * Sets the long file mode for the resulting tar file.  Valid values are "gnu", "posix", "error" or "truncate"
+     * @see org.apache.commons.compress.archivers.tar.TarArchiveOutputStream#setLongFileMode(int)
+     */
+    @Parameter(defaultValue = "gnu")
+    private String tarLongFileMode;
+
+    /**
+     * Sets the big number mode for the resulting tar file.  Valid values are "gnu", "posix" or "error"
+     * @see org.apache.commons.compress.archivers.tar.TarArchiveOutputStream#setBigNumberMode(int)
+     */
+    @Parameter(defaultValue = "error")
+    private String tarBigNumberMode;
+
     /* end of parameters */
 
     private static final String KEY = "key";
@@ -563,6 +577,8 @@ public class DebMojo extends AbstractMojo {
             debMaker.setOpenReplaceToken(openReplaceToken);
             debMaker.setCloseReplaceToken(closeReplaceToken);
             debMaker.setDigest(digest);
+            debMaker.setTarBigNumberMode(tarBigNumberMode);
+            debMaker.setTarLongFileMode(tarLongFileMode);
             debMaker.validate();
             debMaker.makeDeb();
 

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -342,14 +342,14 @@ public class DebMojo extends AbstractMojo {
      * Sets the long file mode for the resulting tar file.  Valid values are "gnu", "posix", "error" or "truncate"
      * @see org.apache.commons.compress.archivers.tar.TarArchiveOutputStream#setLongFileMode(int)
      */
-    @Parameter(defaultValue = "gnu")
+    @Parameter(defaultValue = "posix")
     private String tarLongFileMode;
 
     /**
      * Sets the big number mode for the resulting tar file.  Valid values are "gnu", "posix" or "error"
      * @see org.apache.commons.compress.archivers.tar.TarArchiveOutputStream#setBigNumberMode(int)
      */
-    @Parameter(defaultValue = "error")
+    @Parameter(defaultValue = "posix")
     private String tarBigNumberMode;
 
     /* end of parameters */

--- a/src/test/java/org/vafer/jdeb/DataBuilderTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DataBuilderTestCase.java
@@ -46,7 +46,7 @@ public class DataBuilderTestCase extends TestCase {
         fileset.setProject(project);
 
         StringBuilder md5s = new StringBuilder();
-        builder.buildData(Arrays.asList((DataProducer) new DataProducerFileSet(fileset)), new File("target/data.tar"), md5s, Compression.GZIP);
+        builder.buildData(Arrays.asList((DataProducer) new DataProducerFileSet(fileset)), new File("target/data.tar"), md5s, new TarOptions().compression(Compression.GZIP));
 
         assertTrue("empty md5 file", md5s.length() > 0);
         assertFalse("windows path separator found", md5s.indexOf("\\") != -1);
@@ -63,7 +63,7 @@ public class DataBuilderTestCase extends TestCase {
 
         DataProducer producer = new DataProducerFile(new File("pom.xml"), "/usr/share/myapp/pom.xml", null, null, null);
 
-        builder.buildData(Arrays.asList(producer), archive, new StringBuilder(), Compression.NONE);
+        builder.buildData(Arrays.asList(producer), archive, new StringBuilder(), new TarOptions().compression(Compression.NONE));
 
         int count = 0;
         TarArchiveInputStream in = null;


### PR DESCRIPTION
Fixes for #230.

I wasn't sure of the best way to add test cases for this.  There does not seem to be a way to verify the modes on the resulting tar file.  I did test it locally to ensure it works.