### PR TITLE
Bugfix: correctly derive the .changes file

### DIFF
--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -20,6 +20,7 @@ import org.apache.commons.compress.archivers.ar.ArArchiveEntry;
 import org.apache.commons.compress.archivers.ar.ArArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.crypto.digests.MD5Digest;
@@ -352,7 +353,7 @@ public class DebMaker {
 
     private void makeChangesFiles(final BinaryPackageControlFile packageControlFile) throws PackagingException {
         if (changesOut == null) {
-            changesOut = new File(deb.getParentFile(), deb.getName().replace(".deb", ".changes"));
+            changesOut = new File(deb.getParentFile(), FilenameUtils.getBaseName(deb.getName()) + ".changes");
         }
 
         ChangesProvider changesProvider;


### PR DESCRIPTION
If destfile in the jdeb ant task does not end with .deb then it doesn't correctly derive the .changes file and ends up overriding the deb package we just created.

https://github.com/tcurdt/jdeb/issues/246