### PR TITLE
Not ignore fullpath on tarfileset

### DIFF
--- a/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
@@ -93,7 +93,7 @@ public final class DataProducerFileSet implements DataProducer {
 
             final InputStream inputStream = new FileInputStream(file);
             try {
-                final String entryName = (fullpath.equals("") ? prefix + "/" + name : fullpath);
+                final String entryName = "".equals(fullpath) ? prefix + "/" + name : fullpath;
 
                 final File entryPath = new File(entryName);
 

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
@@ -70,7 +70,8 @@ public final class DataProducerFileSet implements DataProducer {
         final File basedir = scanner.getBasedir();
 
         if (scanner.getIncludedFilesCount() != 1 || scanner.getIncludedDirsCount() != 0) {
-            //this isn't a single-file tarfileset, ignoring the fullpath
+            // the full path attribute only have sense in this context
+            // if it's a single-file fileset, we ignore it otherwise
             fullpath = "";
         }
 

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerFileSet.java
@@ -50,6 +50,7 @@ public final class DataProducerFileSet implements DataProducer {
         int filemode = TarEntry.DEFAULT_FILE_MODE;
         int dirmode = TarEntry.DEFAULT_DIR_MODE;
         String prefix = "";
+        String fullpath = "";
 
         if (fileset instanceof Tar.TarFileSet) {
             Tar.TarFileSet tarfileset = (Tar.TarFileSet) fileset;
@@ -60,12 +61,18 @@ public final class DataProducerFileSet implements DataProducer {
             filemode = tarfileset.getMode();
             dirmode = tarfileset.getDirMode(tarfileset.getProject());
             prefix = tarfileset.getPrefix(tarfileset.getProject());
+            fullpath = tarfileset.getFullpath();
         }
 
         final DirectoryScanner scanner = fileset.getDirectoryScanner(fileset.getProject());
         scanner.scan();
 
         final File basedir = scanner.getBasedir();
+
+        if (scanner.getIncludedFilesCount() != 1 || scanner.getIncludedDirsCount() != 0) {
+            //this isn't a single-file tarfileset, ignoring the fullpath
+            fullpath = "";
+        }
 
         for (String directory : scanner.getIncludedDirectories()) {
             String name = directory.replace('\\', '/');
@@ -86,7 +93,7 @@ public final class DataProducerFileSet implements DataProducer {
 
             final InputStream inputStream = new FileInputStream(file);
             try {
-                final String entryName = prefix + "/" + name;
+                final String entryName = (fullpath.equals("") ? prefix + "/" + name : fullpath);
 
                 final File entryPath = new File(entryName);
 


### PR DESCRIPTION
This PR is trying to resolve #245, this take the fullpath attribute from the tarfileset and use it to define the entryName of the file, but only if the tarfileset is a single-file fileset.