### PR TITLE
If DebMaker.depends is set, then set it in the control file

### DIFF
--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -503,6 +503,12 @@ public class DebMaker {
             if (packageControlFile.get("Description") == null) {
                 packageControlFile.set("Description", description);
             }
+            if (packageControlFile.get("Depends") == null) {
+                // Only add a depends entry to the control file if the field in this object has actually been set
+                if (depends != null && depends.length() > 0) {
+                    packageControlFile.set("Depends", depends);
+                }
+            }
             if (packageControlFile.get("Homepage") == null) {
                 packageControlFile.set("Homepage", homepage);
             }


### PR DESCRIPTION
This PR makes DebMaker include the depends field in the control file if and only if the field was set.

When the change to no longer include the default depends was made in #209 to fix #208 it entirely eliminated the ability to set the depends programatically. In fact, the field DebMaker.depends is never read.

It does not appear that removing support for setting depends programmatically was intended by the conversations in #209 and #208. 