### PR TITLE
Produce relative paths

### DIFF
--- a/src/main/java/org/vafer/jdeb/mapping/PermMapper.java
+++ b/src/main/java/org/vafer/jdeb/mapping/PermMapper.java
@@ -56,10 +56,10 @@ public final class PermMapper implements Mapper {
     }
 
     public TarArchiveEntry map( final TarArchiveEntry entry ) {
-        entry.setName(Utils.joinUnixPath(
-                prefix,
-                Utils.stripPath(strip, entry.getName()
-                )));
+        entry.setName(Utils.stripLeadingSlash(Utils.joinUnixPath(
+            prefix,
+            Utils.stripPath(strip, entry.getName())
+        )));
 
         // Set ownership
         if (uid > -1) {

--- a/src/main/java/org/vafer/jdeb/utils/Utils.java
+++ b/src/main/java/org/vafer/jdeb/utils/Utils.java
@@ -88,12 +88,10 @@ public final class Utils {
         final StringBuilder sb = new StringBuilder();
         for (String p : paths) {
             if (p == null) continue;
-            if (p.startsWith("/")) {
-                sb.append(p);
-            } else {
+            if (!p.startsWith("/") && sb.length() > 0) {
                 sb.append(sep);
-                sb.append(p);
             }
+            sb.append(p);
         }
         return sb.toString();
     }

--- a/src/test/java/org/vafer/jdeb/DebMakerLongNameTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DebMakerLongNameTestCase.java
@@ -16,7 +16,6 @@ import org.vafer.jdeb.producers.DataProducerLink;
 import org.vafer.jdeb.producers.DataProducerPathTemplate;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -79,10 +78,10 @@ public class DebMakerLongNameTestCase extends Assert {
 
         assertTrue(packageControlFile.isValid());
 
-        final Map<String, TarArchiveEntry> filesInDeb = new HashMap<String, TarArchiveEntry>();
+        final Map<String, TarArchiveEntry> filesInDeb = new HashMap<>();
 
         ArchiveWalker.walkData(deb, new ArchiveVisitor<TarArchiveEntry>() {
-            public void visit(TarArchiveEntry entry, byte[] content) throws IOException {
+            public void visit(TarArchiveEntry entry, byte[] content) {
                 filesInDeb.put(entry.getName(), entry);
             }
         }, Compression.GZIP);
@@ -94,7 +93,6 @@ public class DebMakerLongNameTestCase extends Assert {
 
     private String createLongPath(int numDirectories, int nameLength) {
         StringBuilder builder = new StringBuilder();
-        builder.append(FOLDER_SEPARATOR);
         for(int i = 0; i < numDirectories; ++i) {
             builder.append(i);
             builder.append(FOLDER_SEPARATOR);

--- a/src/test/java/org/vafer/jdeb/mapping/PermMapperTest.java
+++ b/src/test/java/org/vafer/jdeb/mapping/PermMapperTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2007-2021 The jdeb developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.vafer.jdeb.mapping;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class PermMapperTest extends Assert {
+
+    @Test
+    public void testEntryNameWithRelativePath() {
+        PermMapper mapper = createMapper();
+        TarArchiveEntry mappedEntry = mapper.map(new TarArchiveEntry("foo/bar", true));
+        assertEquals("", "foo/bar", mappedEntry.getName());
+    }
+
+    @Test
+    public void testEntryNameWithAbsolutePath() {
+        PermMapper mapper = createMapper();
+        TarArchiveEntry mappedEntry = mapper.map(new TarArchiveEntry("/foo/bar", true));
+        assertEquals("", "foo/bar", mappedEntry.getName());
+    }
+
+    PermMapper createMapper() {
+        return new PermMapper(-1, -1, null, null, null, null, -1, null);
+    }
+}

--- a/src/test/java/org/vafer/jdeb/utils/UtilsTestCase.java
+++ b/src/test/java/org/vafer/jdeb/utils/UtilsTestCase.java
@@ -17,6 +17,7 @@
 package org.vafer.jdeb.utils;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Calendar;
@@ -29,14 +30,14 @@ import org.junit.Assert;
 public final class UtilsTestCase extends Assert {
 
     @Test
-    public void testJoinPath() throws Exception {
-        assertEquals("", "/foo/bar", Utils.joinUnixPath(null, "foo", "bar"));
+    public void testJoinPath() {
+        assertEquals("", "foo/bar", Utils.joinUnixPath(null, "foo", "bar"));
         assertEquals("", "/foo/bar", Utils.joinUnixPath(null, "/foo", "/bar"));
-        assertEquals("", "/foo/bar", Utils.joinUnixPath(null, "foo/bar"));
+        assertEquals("", "foo/bar", Utils.joinUnixPath(null, "foo/bar"));
     }
 
-        @Test
-    public void testStripPath() throws Exception {
+    @Test
+    public void testStripPath() {
         assertEquals("foo/bar", Utils.stripPath(0, "foo/bar"));
 
         assertEquals("bar", Utils.stripPath(1, "foo/bar"));
@@ -50,8 +51,8 @@ public final class UtilsTestCase extends Assert {
     }
 
     private String convert(String s) throws Exception {
-        byte[] data = Utils.toUnixLineEndings(new ByteArrayInputStream(s.getBytes("UTF-8")));
-        return new String(data, "UTF-8");
+        byte[] data = Utils.toUnixLineEndings(new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8)));
+        return new String(data, StandardCharsets.UTF_8);
     }
 
     @Test
@@ -77,7 +78,7 @@ public final class UtilsTestCase extends Assert {
 
     @Test
     public void testReplaceVariables() {
-        Map<String, String> variables = new HashMap<String, String>();
+        Map<String, String> variables = new HashMap<>();
         variables.put("version", "1.2.3");
         variables.put("name", "jdeb");
         variables.put("url", "https://github.com/tcurdt/jdeb");
@@ -99,7 +100,7 @@ public final class UtilsTestCase extends Assert {
         assertEquals("if [[ \"${HOST_TYPE}\" -eq \"admin\" ]] ; then", result);
 
         // collision with python syntax
-        input = "c[t][\'A\']";
+        input = "c[t]['A']";
         result = Utils.replaceVariables(resolver, input, "[[", "]]");
         assertEquals(input, result);
 
@@ -123,8 +124,8 @@ public final class UtilsTestCase extends Assert {
     }
 
     @Test
-    public void testReplaceVariablesWithinOpenCloseTokens() throws Exception {
-        Map<String, String> variables = new HashMap<String, String>();
+    public void testReplaceVariablesWithinOpenCloseTokens() {
+        Map<String, String> variables = new HashMap<>();
         variables.put("artifactId", "jdeb");
 
         VariableResolver resolver = new MapVariableResolver(variables);


### PR DESCRIPTION
When upgrading the jdeb dependency in the gradle-debian-plugin, I stumbled upon failing tests. The tests related to paths which had been relative (no leading `/` or having a `./` instead), but got a leading `/` with jdeb 1.7 and jdeb 1.8.

This change reverts the behaviour back to jdeb 1.6 with two combined changes:
- `Utils#joinUnixPath` now doesn't prepend a `/` anymore (so, it only joins now)
- `PermMapper#map` removes any leading `/`, just like Apache commons-compress did in versions up to 1.10.

Relates to #264
