### PR TITLE
Allow constant modified time to support reproducibility

### DIFF
--- a/docs/ant.md
+++ b/docs/ant.md
@@ -182,3 +182,8 @@ the conffiles file. You only have to set the `conffile` attribute to `true`.
       </deb>
     </target>
 ```
+
+## Reproducible builds
+
+Starting with version 1.9, the jdeb supports reproducible builds. You can use `SOURCE_DATE_EPOCH`
+environment variable, containing int representing seconds since the epoch.

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -140,6 +140,7 @@ verbose          | Verbose logging                                              
 skip             | Indicates if an execution should be skipped                                                | No; defaults to `false`
 skipSubmodules   | Skip goal on all submodules                                                                | No; defaults to `false`
 skipPOMs         | Skip goal on POM artifacts                                                                 | No; defaults to `true`
+modifiedTimeMs   | Sets specified modified time in epoch milliseconds to all files and folders                | No; defaults to current time
 
 If you use the `dataSet` element, you'll need to populate it with a one or
 more `data` elements. A `data` element is used to specify a directory, a

--- a/docs/maven.md
+++ b/docs/maven.md
@@ -140,7 +140,6 @@ verbose          | Verbose logging                                              
 skip             | Indicates if an execution should be skipped                                                | No; defaults to `false`
 skipSubmodules   | Skip goal on all submodules                                                                | No; defaults to `false`
 skipPOMs         | Skip goal on POM artifacts                                                                 | No; defaults to `true`
-modifiedTimeMs   | Sets specified modified time in epoch milliseconds to all files and folders                | No; defaults to current time
 
 If you use the `dataSet` element, you'll need to populate it with a one or
 more `data` elements. A `data` element is used to specify a directory, a
@@ -317,3 +316,15 @@ If you don't want to store your key information in the POM you can store this in
   </settings>
 ```
 keyring, key and passphrase can then be omitted from the POM entirely.
+
+Starting with version 1.9, the jdeb supports reproducible builds. You can add `project.build.outputTimestamp` to `properties` in your pom.xml,
+containing either string formatted as ISO 8601 `yyyy-MM-dd'T'HH:mm:ssXXX` or as an int representing seconds since the epoch.
+
+```xml
+  <properties>
+    <project.build.outputTimestamp>2021-01-01T12:00:00Z</project.build.outputTimestamp>
+  </properties>
+```
+You may also use `SOURCE_DATE_EPOCH` environment variable, containing int representing seconds since the epoch.
+
+Note that if you use both `project.build.outputTimestamp` in pom.xml and `SOURCE_DATE_EPOCH` environment variable, the value in pom.xml takes precedence.

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
       <version>1.9</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-archiver</artifactId>
+      <version>3.5.1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/src/main/java/org/vafer/jdeb/ControlBuilder.java
+++ b/src/main/java/org/vafer/jdeb/ControlBuilder.java
@@ -60,14 +60,14 @@ class ControlBuilder {
     private VariableResolver resolver;
     private final String openReplaceToken;
     private final String closeReplaceToken;
-    private final Long modifiedTimeMs;
+    private final Long outputTimestampMs;
 
-    ControlBuilder(Console console, VariableResolver resolver, String openReplaceToken, String closeReplaceToken, Long modifiedTimeMs) {
+    ControlBuilder(Console console, VariableResolver resolver, String openReplaceToken, String closeReplaceToken, Long outputTimestampMs) {
         this.console = console;
         this.resolver = resolver;
         this.openReplaceToken = openReplaceToken;
         this.closeReplaceToken = closeReplaceToken;
-        this.modifiedTimeMs = modifiedTimeMs;
+        this.outputTimestampMs = outputTimestampMs;
     }
 
     /**
@@ -216,8 +216,8 @@ class ControlBuilder {
         final TarArchiveEntry entry = new TarArchiveEntry("./" + pName, true);
         entry.setSize(data.length);
         entry.setNames("root", "root");
-        if (modifiedTimeMs != null) {
-            entry.setModTime(modifiedTimeMs);
+        if (outputTimestampMs != null) {
+            entry.setModTime(outputTimestampMs);
         }
 
         if (MAINTAINER_SCRIPTS.contains(pName)) {

--- a/src/main/java/org/vafer/jdeb/ControlBuilder.java
+++ b/src/main/java/org/vafer/jdeb/ControlBuilder.java
@@ -60,12 +60,14 @@ class ControlBuilder {
     private VariableResolver resolver;
     private final String openReplaceToken;
     private final String closeReplaceToken;
+    private final Long modifiedTimeMs;
 
-    ControlBuilder(Console console, VariableResolver resolver, String openReplaceToken, String closeReplaceToken) {
+    ControlBuilder(Console console, VariableResolver resolver, String openReplaceToken, String closeReplaceToken, Long modifiedTimeMs) {
         this.console = console;
         this.resolver = resolver;
         this.openReplaceToken = openReplaceToken;
         this.closeReplaceToken = closeReplaceToken;
+        this.modifiedTimeMs = modifiedTimeMs;
     }
 
     /**
@@ -208,12 +210,15 @@ class ControlBuilder {
     }
 
 
-    private static void addControlEntry(final String pName, final String pContent, final TarArchiveOutputStream pOutput) throws IOException {
+    private void addControlEntry(final String pName, final String pContent, final TarArchiveOutputStream pOutput) throws IOException {
         final byte[] data = pContent.getBytes(UTF_8);
 
         final TarArchiveEntry entry = new TarArchiveEntry("./" + pName, true);
         entry.setSize(data.length);
         entry.setNames("root", "root");
+        if (modifiedTimeMs != null) {
+            entry.setModTime(modifiedTimeMs);
+        }
 
         if (MAINTAINER_SCRIPTS.contains(pName)) {
             entry.setMode(PermMapper.toMode("755"));

--- a/src/main/java/org/vafer/jdeb/DataBuilder.java
+++ b/src/main/java/org/vafer/jdeb/DataBuilder.java
@@ -46,6 +46,8 @@ class DataBuilder {
 
     private ZipEncoding encoding;
 
+    private final Long modifiedTimeMs;
+
     private static final class Total {
         private BigInteger count = BigInteger.valueOf(0);
 
@@ -58,9 +60,10 @@ class DataBuilder {
         }
     }
 
-    DataBuilder(Console console) {
+    DataBuilder(Console console, Long modifiedTimeMs) {
         this.console = console;
         this.encoding = ZipEncodingHelper.getZipEncoding(null);
+        this.modifiedTimeMs = modifiedTimeMs;
     }
 
     private void checkField(String name, int length) throws IOException {
@@ -136,6 +139,9 @@ class DataBuilder {
                 String rawFileEntryName = fileEntry.getName();
 
                 fileEntry.setName(fixPathTar(fileEntry.getName()));
+                if (modifiedTimeMs != null) {
+                    fileEntry.setModTime(modifiedTimeMs);
+                }
 
                 createParentDirectories(fileEntry.getName(), fileEntry.getUserName(), fileEntry.getLongUserId(), fileEntry.getGroupName(), fileEntry.getLongGroupId());
 
@@ -174,6 +180,9 @@ class DataBuilder {
                 checkField(entry.getGroupName(), TarConstants.GNAMELEN);
 
                 entry.setName(fixPathTar(entry.getName()));
+                if (modifiedTimeMs != null) {
+                    entry.setModTime(modifiedTimeMs);
+                }
 
                 createParentDirectories(entry.getName(), entry.getUserName(), entry.getLongUserId(), entry.getGroupName(), entry.getLongGroupId());
 
@@ -209,6 +218,10 @@ class DataBuilder {
                     entry.setGroupId(gid);
                     entry.setMode(mode);
                     entry.setSize(size);
+
+                    if (modifiedTimeMs != null) {
+                        entry.setModTime(modifiedTimeMs);
+                    }
 
                     tarOutputStream.putArchiveEntry(entry);
                     tarOutputStream.closeArchiveEntry();

--- a/src/main/java/org/vafer/jdeb/DataBuilder.java
+++ b/src/main/java/org/vafer/jdeb/DataBuilder.java
@@ -46,7 +46,7 @@ class DataBuilder {
 
     private ZipEncoding encoding;
 
-    private final Long modifiedTimeMs;
+    private final Long outputTimestampMs;
 
     private static final class Total {
         private BigInteger count = BigInteger.valueOf(0);
@@ -60,10 +60,10 @@ class DataBuilder {
         }
     }
 
-    DataBuilder(Console console, Long modifiedTimeMs) {
+    DataBuilder(Console console, Long outputTimestampMs) {
         this.console = console;
         this.encoding = ZipEncodingHelper.getZipEncoding(null);
-        this.modifiedTimeMs = modifiedTimeMs;
+        this.outputTimestampMs = outputTimestampMs;
     }
 
     private void checkField(String name, int length) throws IOException {
@@ -139,8 +139,8 @@ class DataBuilder {
                 String rawFileEntryName = fileEntry.getName();
 
                 fileEntry.setName(fixPathTar(fileEntry.getName()));
-                if (modifiedTimeMs != null) {
-                    fileEntry.setModTime(modifiedTimeMs);
+                if (outputTimestampMs != null) {
+                    fileEntry.setModTime(outputTimestampMs);
                 }
 
                 createParentDirectories(fileEntry.getName(), fileEntry.getUserName(), fileEntry.getLongUserId(), fileEntry.getGroupName(), fileEntry.getLongGroupId());
@@ -180,8 +180,8 @@ class DataBuilder {
                 checkField(entry.getGroupName(), TarConstants.GNAMELEN);
 
                 entry.setName(fixPathTar(entry.getName()));
-                if (modifiedTimeMs != null) {
-                    entry.setModTime(modifiedTimeMs);
+                if (outputTimestampMs != null) {
+                    entry.setModTime(outputTimestampMs);
                 }
 
                 createParentDirectories(entry.getName(), entry.getUserName(), entry.getLongUserId(), entry.getGroupName(), entry.getLongGroupId());
@@ -219,8 +219,8 @@ class DataBuilder {
                     entry.setMode(mode);
                     entry.setSize(size);
 
-                    if (modifiedTimeMs != null) {
-                        entry.setModTime(modifiedTimeMs);
+                    if (outputTimestampMs != null) {
+                        entry.setModTime(outputTimestampMs);
                     }
 
                     tarOutputStream.putArchiveEntry(entry);

--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -63,6 +63,9 @@ import java.util.Locale;
  */
 public class DebMaker {
 
+    private static final int DEFAULT_MODE = 33188;
+    private static final int MILIS_IN_SECOND = 1000;
+
     /** A console to output log message with */
     private Console console;
 
@@ -125,6 +128,8 @@ public class DebMaker {
 
     /** Defines the bigNumberMode of the tar file that is built */
     private String tarBigNumberMode;
+
+    private Long modifiedTimeMs;
 
     private VariableResolver variableResolver;
     private String openReplaceToken;
@@ -241,6 +246,10 @@ public class DebMaker {
 
     public void setTarBigNumberMode(String tarBigNumberMode) {
         this.tarBigNumberMode = tarBigNumberMode;
+    }
+
+    public void setConstantModifiedTime(Long modifiedTimeMs) {
+        this.modifiedTimeMs = modifiedTimeMs;
     }
 
     /**
@@ -473,7 +482,7 @@ public class DebMaker {
             tempControl = File.createTempFile("deb", "control");
 
             console.debug("Building data");
-            DataBuilder dataBuilder = new DataBuilder(console);
+            DataBuilder dataBuilder = new DataBuilder(console, modifiedTimeMs);
             StringBuilder md5s = new StringBuilder();
             TarOptions options = new TarOptions()
                 .compression(compression)
@@ -485,7 +494,7 @@ public class DebMaker {
             List<String> tempConffiles = populateConffiles(conffilesProducers);
 
             console.debug("Building control");
-            ControlBuilder controlBuilder = new ControlBuilder(console, variableResolver, openReplaceToken, closeReplaceToken);
+            ControlBuilder controlBuilder = new ControlBuilder(console, variableResolver, openReplaceToken, closeReplaceToken, modifiedTimeMs);
             BinaryPackageControlFile packageControlFile = controlBuilder.createPackageControlFile(new File(control, "control"), size);
             if (packageControlFile.get("Package") == null) {
                 packageControlFile.set("Package", packageName);
@@ -661,15 +670,18 @@ public class DebMaker {
 
     private void addTo(ArArchiveOutputStream pOutput, String pName, String pContent) throws IOException {
         final byte[] content = pContent.getBytes();
-        pOutput.putArchiveEntry(new ArArchiveEntry(pName, content.length));
+        ArArchiveEntry archiveEntry = createArArchiveEntry(pName, content.length);
+
+        pOutput.putArchiveEntry(archiveEntry);
         pOutput.write(content);
         pOutput.closeArchiveEntry();
     }
 
     private void addTo(ArArchiveOutputStream pOutput, String pName, File pContent) throws IOException {
-        pOutput.putArchiveEntry(new ArArchiveEntry(pName, pContent.length()));
+        ArArchiveEntry archiveEntry = createArArchiveEntry(pName, pContent.length());
 
-        try (InputStream input = new FileInputStream(pContent)) {
+        pOutput.putArchiveEntry(archiveEntry);
+		try (InputStream input = new FileInputStream(pContent)) {
             Utils.copy(input, pOutput);
         }
 
@@ -693,5 +705,13 @@ public class DebMaker {
 
     public void setCloseReplaceToken(String closeReplaceToken) {
         this.closeReplaceToken = closeReplaceToken;
+    }
+
+    private ArArchiveEntry createArArchiveEntry(String pName, long contentLength) {
+        if (modifiedTimeMs != null) {
+            return new ArArchiveEntry(pName, contentLength, 0, 0, DEFAULT_MODE, modifiedTimeMs / MILIS_IN_SECOND);
+        }
+
+        return new ArArchiveEntry(pName, contentLength);
     }
 }

--- a/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
+++ b/src/main/java/org/vafer/jdeb/ant/DebAntTask.java
@@ -31,6 +31,7 @@ import org.vafer.jdeb.DataProducer;
 import org.vafer.jdeb.DebMaker;
 import org.vafer.jdeb.PackagingException;
 import org.vafer.jdeb.producers.DataProducerFileSet;
+import org.vafer.jdeb.utils.OutputTimestampResolver;
 
 /**
  * AntTask for creating debian archives.
@@ -174,6 +175,8 @@ public class DebAntTask extends MatchingTask {
         debMaker.setPassphrase(passphrase);
         debMaker.setCompression(compression);
         debMaker.setDigest(digest);
+        Long outputTimestampMs = new OutputTimestampResolver(console).resolveOutputTimestamp(null);
+        debMaker.setOutputTimestampMs(outputTimestampMs);
 
         try {
             debMaker.validate();

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -51,6 +51,7 @@ import org.vafer.jdeb.DataProducer;
 import org.vafer.jdeb.DebMaker;
 import org.vafer.jdeb.PackagingException;
 import org.vafer.jdeb.utils.MapVariableResolver;
+import org.vafer.jdeb.utils.OutputTimestampResolver;
 import org.vafer.jdeb.utils.SymlinkUtils;
 import org.vafer.jdeb.utils.Utils;
 import org.vafer.jdeb.utils.VariableResolver;
@@ -360,10 +361,14 @@ public class DebMojo extends AbstractMojo {
     private String tarBigNumberMode;
 
     /**
-     * Epoch time in milliseconds that will be used as 'modified time' for all files and folders.
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601
+     * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
+     * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     *
+     * @since 1.9
      */
-    @Parameter
-    private Long modifiedTimeMs;
+    @Parameter(defaultValue = "${project.build.outputTimestamp}")
+    private String outputTimestamp;
 
     /* end of parameters */
 
@@ -597,7 +602,8 @@ public class DebMojo extends AbstractMojo {
             debMaker.setDigest(digest);
             debMaker.setTarBigNumberMode(tarBigNumberMode);
             debMaker.setTarLongFileMode(tarLongFileMode);
-            debMaker.setConstantModifiedTime(modifiedTimeMs);
+            Long outputTimestampMs = new OutputTimestampResolver(console).resolveOutputTimestamp(outputTimestamp);
+            debMaker.setOutputTimestampMs(outputTimestampMs);
             debMaker.validate();
             debMaker.makeDeb();
 

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -359,6 +359,12 @@ public class DebMojo extends AbstractMojo {
     @Parameter(defaultValue = "gnu")
     private String tarBigNumberMode;
 
+    /**
+     * Epoch time in milliseconds that will be used as 'modified time' for all files and folders.
+     */
+    @Parameter
+    private Long modifiedTimeMs;
+
     /* end of parameters */
 
     private static final String KEY = "key";
@@ -591,6 +597,7 @@ public class DebMojo extends AbstractMojo {
             debMaker.setDigest(digest);
             debMaker.setTarBigNumberMode(tarBigNumberMode);
             debMaker.setTarLongFileMode(tarLongFileMode);
+            debMaker.setConstantModifiedTime(modifiedTimeMs);
             debMaker.validate();
             debMaker.makeDeb();
 

--- a/src/main/java/org/vafer/jdeb/utils/OutputTimestampResolver.java
+++ b/src/main/java/org/vafer/jdeb/utils/OutputTimestampResolver.java
@@ -1,0 +1,50 @@
+package org.vafer.jdeb.utils;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.maven.archiver.MavenArchiver;
+import org.vafer.jdeb.Console;
+
+public class OutputTimestampResolver {
+    private final Console console;
+    private final EnvironmentVariablesReader envReader;
+
+    public OutputTimestampResolver(Console console) {
+        this(console, new EnvironmentVariablesReader());
+    }
+
+    OutputTimestampResolver(Console console, EnvironmentVariablesReader envReader) {
+        this.console = console;
+        this.envReader = envReader;
+    }
+
+    public Long resolveOutputTimestamp(String paramValue) {
+        if (paramValue != null) {
+            Date outputDate = new MavenArchiver().parseOutputTimestamp(paramValue);
+            if (outputDate != null) {
+                console.info("Accepted outputTimestamp parameter: " + paramValue);
+                return outputDate.getTime();
+            }
+        }
+
+        String sourceDate = envReader.getSourceDateEpoch();
+        if (sourceDate != null && !sourceDate.isEmpty()) {
+            try {
+                long sourceDateVal = Long.parseLong(sourceDate);
+                console.info("Accepted SOURCE_DATE_EPOCH environment variable: " + sourceDate);
+                return sourceDateVal * TimeUnit.SECONDS.toMillis(1);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid SOURCE_DATE_EPOCH environment variable value: " + sourceDate, e);
+            }
+        }
+
+        return null;
+    }
+
+    static class EnvironmentVariablesReader {
+        String getSourceDateEpoch() {
+            return System.getenv("SOURCE_DATE_EPOCH");
+        }
+    }
+}

--- a/src/test/java/org/vafer/jdeb/DataBuilderTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DataBuilderTestCase.java
@@ -34,7 +34,7 @@ import org.vafer.jdeb.producers.DataProducerLink;
 
 public final class DataBuilderTestCase extends Assert {
 
-    private static final long MODIFIED_TIME = 1609455600000L;
+    private static final long EXPECTED_MODIFIED_TIME = 1609455600000L;
 
     /**
      * Checks if the file paths in the md5sums file use only unix file separators
@@ -89,7 +89,7 @@ public final class DataBuilderTestCase extends Assert {
         DataProducer linkProducer = new DataProducerLink("pomLink.xml", "/usr/share/myapp/pom.xml", true, null, null, null);
         File archive = prepareArchive();
 
-        DataBuilder builder = new DataBuilder(new NullConsole(), MODIFIED_TIME);
+        DataBuilder builder = new DataBuilder(new NullConsole(), EXPECTED_MODIFIED_TIME);
         builder.buildData(Arrays.asList(fileProducer, linkProducer, dirProducer), archive, new StringBuilder(), new TarOptions().compression(Compression.NONE));
 
         assertExpectedModTimeInArchive(archive);
@@ -123,7 +123,7 @@ public final class DataBuilderTestCase extends Assert {
         try (TarArchiveInputStream in = new TarArchiveInputStream(new FileInputStream(archive))) {
             ArchiveEntry entry = in.getNextEntry();
             while (entry != null) {
-                assertEquals(MODIFIED_TIME, entry.getLastModifiedDate().getTime());
+                assertEquals(EXPECTED_MODIFIED_TIME, entry.getLastModifiedDate().getTime());
 
                 entry = in.getNextEntry();
             }

--- a/src/test/java/org/vafer/jdeb/DataBuilderTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DataBuilderTestCase.java
@@ -18,18 +18,23 @@ package org.vafer.jdeb;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 
-import org.junit.Test;
-import org.junit.Assert;
-
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.FileSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.vafer.jdeb.producers.DataProducerDirectory;
 import org.vafer.jdeb.producers.DataProducerFile;
 import org.vafer.jdeb.producers.DataProducerFileSet;
+import org.vafer.jdeb.producers.DataProducerLink;
 
 public final class DataBuilderTestCase extends Assert {
+
+    private static final long MODIFIED_TIME = 1609455600000L;
 
     /**
      * Checks if the file paths in the md5sums file use only unix file separators
@@ -37,7 +42,7 @@ public final class DataBuilderTestCase extends Assert {
      */
     @Test
     public void testBuildDataWithFileSet() throws Exception {
-        DataBuilder builder = new DataBuilder(new NullConsole());
+        DataBuilder builder = new DataBuilder(new NullConsole(), null);
 
         Project project = new Project();
         project.setCoreLoader(getClass().getClassLoader());
@@ -58,12 +63,9 @@ public final class DataBuilderTestCase extends Assert {
 
     @Test
     public void testCreateParentDirectories() throws Exception {
-        File archive = new File("target/data.tar");
-        if (archive.exists()) {
-            archive.delete();
-        }
+        File archive = prepareArchive();
 
-        DataBuilder builder = new DataBuilder(new NullConsole());
+        DataBuilder builder = new DataBuilder(new NullConsole(), null);
 
         DataProducer producer = new DataProducerFile(new File("pom.xml"), "/usr/share/myapp/pom.xml", null, null, null);
 
@@ -77,5 +79,54 @@ public final class DataBuilderTestCase extends Assert {
         }
 
         assertEquals("entries", 4, count);
+    }
+
+    @Test
+    public void testModifiedTimeIsSet() throws Exception {
+        File dir = prepareSubdir();
+        DataProducer dirProducer = new DataProducerDirectory(dir, null, null, null);
+        DataProducer fileProducer = new DataProducerFile(new File("pom.xml"), "/usr/share/myapp/pom.xml", null, null, null);
+        DataProducer linkProducer = new DataProducerLink("pomLink.xml", "/usr/share/myapp/pom.xml", true, null, null, null);
+        File archive = prepareArchive();
+
+        DataBuilder builder = new DataBuilder(new NullConsole(), MODIFIED_TIME);
+        builder.buildData(Arrays.asList(fileProducer, linkProducer, dirProducer), archive, new StringBuilder(), new TarOptions().compression(Compression.NONE));
+
+        assertExpectedModTimeInArchive(archive);
+    }
+
+    private File prepareArchive() {
+        File archive = new File("target/data.tar");
+        if (archive.exists()) {
+            archive.delete();
+        }
+        return archive;
+    }
+
+    private File prepareSubdir() throws IOException {
+        File subDir = new File("target/subDir");
+        subDir.mkdir();
+
+        File file = new File(subDir, "file.txt");
+        file.createNewFile();
+
+        File nestedDir = new File(subDir, "nested-dir");
+        nestedDir.mkdir();
+
+        File file2 = new File(nestedDir, "file2.txt");
+        file2.createNewFile();
+
+        return subDir;
+    }
+
+    private void assertExpectedModTimeInArchive(File archive) throws IOException {
+        try (TarArchiveInputStream in = new TarArchiveInputStream(new FileInputStream(archive))) {
+            ArchiveEntry entry = in.getNextEntry();
+            while (entry != null) {
+                assertEquals(MODIFIED_TIME, entry.getLastModifiedDate().getTime());
+
+                entry = in.getNextEntry();
+            }
+        }
     }
 }

--- a/src/test/java/org/vafer/jdeb/DebMakerTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DebMakerTestCase.java
@@ -42,7 +42,7 @@ import static java.nio.charset.StandardCharsets.*;
 
 public final class DebMakerTestCase extends Assert {
 
-    private static final long MODIFIED_TIME = 1609455600000L;
+    private static final long EXPECTED_MODIFIED_TIME = 1609455600000L;
 
     @Test
     public void testCreation() throws Exception {
@@ -233,7 +233,7 @@ public final class DebMakerTestCase extends Assert {
         DebMaker maker = new DebMaker(new NullConsole(), Arrays.asList(data), confFileProducers);
         maker.setControl(new File(getClass().getResource("deb/control").toURI()));
         maker.setDeb(deb);
-        maker.setConstantModifiedTime(MODIFIED_TIME);
+        maker.setOutputTimestampMs(EXPECTED_MODIFIED_TIME);
 
         BinaryPackageControlFile packageControlFile = maker.createDeb(Compression.GZIP);
 
@@ -262,13 +262,13 @@ public final class DebMakerTestCase extends Assert {
 
     private static class ModifiedTimeAssert implements ArchiveVisitor<TarArchiveEntry> {
         public void visit(TarArchiveEntry entry, byte[] content) throws IOException {
-            assertEquals("Modified time does not match the expected value for " + entry.getName(), entry.getModTime().getTime(), MODIFIED_TIME);
+            assertEquals("Modified time does not match the expected value for " + entry.getName(), entry.getModTime().getTime(), EXPECTED_MODIFIED_TIME);
         }
     }
 
     private static class ArchiveModifiedTimeAssert implements ArchiveVisitor<ArArchiveEntry> {
         public void visit(ArArchiveEntry entry, byte[] content) throws IOException {
-            assertEquals("Modified time does not match the expected value for " + entry.getName(), entry.getLastModified(), MODIFIED_TIME / 1000);
+            assertEquals("Modified time does not match the expected value for " + entry.getName(), entry.getLastModified(), EXPECTED_MODIFIED_TIME / 1000);
         }
     }
 }

--- a/src/test/java/org/vafer/jdeb/DebMakerTestCase.java
+++ b/src/test/java/org/vafer/jdeb/DebMakerTestCase.java
@@ -19,17 +19,18 @@ package org.vafer.jdeb;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.Assert;
-
+import org.apache.commons.compress.archivers.ar.ArArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
+import org.junit.Assert;
+import org.junit.Test;
 import org.vafer.jdeb.debian.BinaryPackageControlFile;
 import org.vafer.jdeb.producers.DataProducerArchive;
 import org.vafer.jdeb.producers.DataProducerDirectory;
@@ -41,23 +42,11 @@ import static java.nio.charset.StandardCharsets.*;
 
 public final class DebMakerTestCase extends Assert {
 
+    private static final long MODIFIED_TIME = 1609455600000L;
+
     @Test
     public void testCreation() throws Exception {
-
-        File control = new File(getClass().getResource("deb/control/control").toURI());
-        File archive1 = new File(getClass().getResource("deb/data.tgz").toURI());
-        File archive2 = new File(getClass().getResource("deb/data.tar.bz2").toURI());
-        File archive3 = new File(getClass().getResource("deb/data.zip").toURI());
-        File directory = new File(getClass().getResource("deb/data").toURI());
-
-        DataProducer[] data = new DataProducer[] {
-            new DataProducerArchive(archive1, null, null, null),
-            new DataProducerArchive(archive2, null, null, null),
-            new DataProducerArchive(archive3, null, null, null),
-            new DataProducerDirectory(directory, null, new String[] { "**/.svn/**" }, null),
-            new DataProducerLink("/link/path-element.ext", "/link/target-element.ext", true, null, null, null)
-        };
-
+        DataProducer[] data = prepareData();
         File deb = File.createTempFile("jdeb", ".deb");
 
         DebMaker maker = new DebMaker(new NullConsole(), Arrays.asList(data), null);
@@ -233,5 +222,53 @@ public final class DebMakerTestCase extends Assert {
         });
 
         assertTrue("Control files not found in the package", found);
+    }
+
+    @Test
+    public void testConstantModifiedTime() throws Exception {
+        DataProducer[] data = prepareData();
+        File deb = File.createTempFile("jdeb", ".deb");
+
+        Collection<DataProducer> confFileProducers = Arrays.asList(new DataProducer[] {new EmptyDataProducer()});
+        DebMaker maker = new DebMaker(new NullConsole(), Arrays.asList(data), confFileProducers);
+        maker.setControl(new File(getClass().getResource("deb/control").toURI()));
+        maker.setDeb(deb);
+        maker.setConstantModifiedTime(MODIFIED_TIME);
+
+        BinaryPackageControlFile packageControlFile = maker.createDeb(Compression.GZIP);
+
+        assertTrue(packageControlFile.isValid());
+        ArchiveWalker.walkArchive(deb, new ArchiveModifiedTimeAssert());
+        ModifiedTimeAssert modifiedTimeAssert = new ModifiedTimeAssert();
+        ArchiveWalker.walkData(deb, modifiedTimeAssert, Compression.GZIP);
+        ArchiveWalker.walkControl(deb, modifiedTimeAssert);
+        assertTrue("Cannot delete the file " + deb, deb.delete());
+    }
+
+    private DataProducer[] prepareData() throws URISyntaxException {
+        File archive1 = new File(getClass().getResource("deb/data.tgz").toURI());
+        File archive2 = new File(getClass().getResource("deb/data.tar.bz2").toURI());
+        File archive3 = new File(getClass().getResource("deb/data.zip").toURI());
+        File directory = new File(getClass().getResource("deb/data").toURI());
+
+        return new DataProducer[] {
+                new DataProducerArchive(archive1, null, null, null),
+                new DataProducerArchive(archive2, null, null, null),
+                new DataProducerArchive(archive3, null, null, null),
+                new DataProducerDirectory(directory, null, new String[] { "**/.svn/**" }, null),
+                new DataProducerLink("/link/path-element.ext", "/link/target-element.ext", true, null, null, null)
+        };
+    }
+
+    private static class ModifiedTimeAssert implements ArchiveVisitor<TarArchiveEntry> {
+        public void visit(TarArchiveEntry entry, byte[] content) throws IOException {
+            assertEquals("Modified time does not match the expected value for " + entry.getName(), entry.getModTime().getTime(), MODIFIED_TIME);
+        }
+    }
+
+    private static class ArchiveModifiedTimeAssert implements ArchiveVisitor<ArArchiveEntry> {
+        public void visit(ArArchiveEntry entry, byte[] content) throws IOException {
+            assertEquals("Modified time does not match the expected value for " + entry.getName(), entry.getLastModified(), MODIFIED_TIME / 1000);
+        }
     }
 }

--- a/src/test/java/org/vafer/jdeb/utils/OutputTimestampResolverTestCase.java
+++ b/src/test/java/org/vafer/jdeb/utils/OutputTimestampResolverTestCase.java
@@ -1,0 +1,89 @@
+package org.vafer.jdeb.utils;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.vafer.jdeb.NullConsole;
+
+public class OutputTimestampResolverTestCase extends Assert {
+    private OutputTimestampResolver resolver;
+    private OutputTimestampResolver.EnvironmentVariablesReader envReader;
+
+    @Before
+    public void setUp() {
+        envReader = mock(OutputTimestampResolver.EnvironmentVariablesReader.class);
+
+        resolver = new OutputTimestampResolver(new NullConsole(), envReader);
+    }
+
+    @Test
+    public void testParameterInIsoFormat() {
+        Long result = resolver.resolveOutputTimestamp("2021-01-01T12:00:00Z");
+
+        assertEquals((Long) 1609502400000L, result);
+    }
+
+    @Test
+    public void testParameterInIsoFormatWithSpecificTimezone() {
+        Long result = resolver.resolveOutputTimestamp("2021-01-01T12:00:00+13:00");
+
+        assertEquals((Long) 1609455600000L, result);
+    }
+
+    @Test
+    public void testParameterInEpochSeconds() {
+        Long result = resolver.resolveOutputTimestamp("1600000000");
+
+        assertEquals((Long) 1600000000000L, result);
+    }
+
+    @Test
+    public void testInvalidParameter() {
+        try {
+            resolver.resolveOutputTimestamp("invalid");
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        fail("Exception expected on invalid value");
+    }
+
+    @Test
+    public void testEnvVariable() {
+        doReturn("1600000000").when(envReader).getSourceDateEpoch();
+
+        Long result = resolver.resolveOutputTimestamp(null);
+
+        assertEquals((Long) 1600000000000L, result);
+    }
+
+    @Test
+    public void testInvalidEnvVariable() {
+        doReturn("invalid").when(envReader).getSourceDateEpoch();
+
+        try {
+            resolver.resolveOutputTimestamp(null);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        fail("Exception expected on invalid value");
+    }
+
+    @Test
+    public void testNoTimestamp() {
+        Long result = resolver.resolveOutputTimestamp(null);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testParamTakesPrecedenceOverEnvVar() {
+        doReturn("1600000000").when(envReader).getSourceDateEpoch();
+
+        Long result = resolver.resolveOutputTimestamp("1610000000");
+
+        assertEquals((Long) 1610000000000L, result);
+    }
+}


### PR DESCRIPTION
Hi,

This change allows users to specify 'modified time' that will be used for all files/folders. This is required to achieve reproducible builds (https://reproducible-builds.org/) of debian packages using this plugin, since there isn't another way how to control the time.

It adds new parameter 'modifiedTimeMs' to the plugin configuration, which (if not left empty) should contain epoch time in milliseconds that will be used as 'modified time'.

Looking forward to hearing from you