### PR TITLE
Use HTTPS for GitHub clone URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The jars are available in the [Maven central repository](https://repo1.maven.org
 If you feel adventurous or want to help out feel free to get the latest code
 [via git](http://github.com/tcurdt/jdeb/tree/master).
 
-    git clone git://github.com/tcurdt/jdeb.git
+    git clone https://github.com/tcurdt/jdeb.git
 
 ## Where to ask questions
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
     <contributor><name>Steven Bower</name></contributor>
   </contributors>
   <scm>
-    <connection>scm:git:git://github.com:tcurdt/jdeb.git</connection>
-    <developerConnection>scm:git:git://github.com:tcurdt/jdeb.git</developerConnection>
+    <connection>scm:git:https://github.com:tcurdt/jdeb.git</connection>
+    <developerConnection>scm:git:https://github.com:tcurdt/jdeb.git</developerConnection>
     <url>http://github.com/tcurdt/jdeb/tree/master</url>
   </scm>
   <distributionManagement>


### PR DESCRIPTION
GitHub has dropped support for the git:// protocol:
https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/