### PR TITLE
Fix Maven integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <maven.scope>provided</maven.scope>
     <maven.version>3.6.0</maven.version>
     <maven.plugin.version>3.10.2</maven.plugin.version>
+    <plexus.sec.version>1.4</plexus.sec.version>
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>
   <prerequisites>
@@ -102,12 +103,6 @@
     <!-- mvn versions:display-dependency-updates -->
     <!-- mvn versions:display-plugin-updates -->
     <dependency>
-      <groupId>org.apache.ant</groupId>
-      <artifactId>ant</artifactId>
-      <version>1.10.14</version>
-      <scope>${maven.scope}</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${maven.version}</version>
@@ -130,6 +125,16 @@
       <artifactId>maven-archiver</artifactId>
       <version>3.6.1</version>
       <scope>${maven.scope}</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.10.14</version>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.plexus</groupId>
+      <artifactId>plexus-sec-dispatcher</artifactId>
+      <version>${plexus.sec.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -155,7 +160,6 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.16.1</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -344,6 +348,7 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.commons:commons-compress</include>
+                  <include>commons-codec:commons-codec</include>
                   <include>commons-io:commons-io</include>
                   <include>org.bouncycastle:bcpg-jdk15on</include>
                   <include>org.bouncycastle:bcprov-jdk15on</include>
@@ -454,8 +459,6 @@
         </executions>
       </plugin>
 
-
-      <!-- FIXME
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
@@ -467,9 +470,10 @@
           <streamLogs>true</streamLogs>
           <settingsFile>src/it/settings.xml</settingsFile>
           <goals>
-              <goal>clean</goal>
-              <goal>package</goal>
-            </goals>
+            <goal>clean</goal>
+            <goal>package</goal>
+          </goals>
+          <showErrors>true</showErrors>
         </configuration>
         <executions>
           <execution>
@@ -477,12 +481,10 @@
             <goals>
               <goal>install</goal>
               <goal>run</goal>
-              </goals>
+            </goals>
             </execution>
           </executions>
         </plugin>
-      -->
-
     </plugins>
   </build>
 


### PR DESCRIPTION
Here are the fixed problems:

* Looks like commons-codec is in fact used (indirectly probably) and since the shade plugin is configured to rename all references to `org.apache.commons` I included it (if you are sure it's only use in the Maven use case I guess an alternative would be to configure the shade plugin with a more restrictive package to rename)
* The mojo seems to need a class located in ant so it cannot be scope provided
* The mojo have a direct dependency on a class located in plexus-sec-dispatcher (to be honest I don't fully understand this one as plexus-sec-dispatcher seems to be part of Maven itself so not sure why it cannot find it, but adding this dependency definitely fix the class not found...)
