### PR TITLE
Update Control Builder,ChangesFileBuilder,pom.xml,DebMaker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <maven.scope>provided</maven.scope>
     <maven.version>3.6.3</maven.version>
     <maven.plugin.version>3.10.2</maven.plugin.version>

--- a/src/main/java/org/vafer/jdeb/ChangesFileBuilder.java
+++ b/src/main/java/org/vafer/jdeb/ChangesFileBuilder.java
@@ -44,7 +44,7 @@ class ChangesFileBuilder {
 
         try {
             // compute the checksums of the binary package
-            InformationOutputStream md5output = new InformationOutputStream(NullOutputStream.NULL_OUTPUT_STREAM, MessageDigest.getInstance("MD5"));
+            InformationOutputStream md5output = new InformationOutputStream(NullOutputStream.INSTANCE, MessageDigest.getInstance("MD5"));
             InformationOutputStream sha1output = new InformationOutputStream(md5output, MessageDigest.getInstance("SHA1"));
             InformationOutputStream sha256output = new InformationOutputStream(sha1output, MessageDigest.getInstance("SHA-256"));
 

--- a/src/main/java/org/vafer/jdeb/ControlBuilder.java
+++ b/src/main/java/org/vafer/jdeb/ControlBuilder.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -132,7 +133,7 @@ class ControlBuilder {
 
                 // initialize the information stream to guess the type of the file
                 InformationInputStream infoStream = new InformationInputStream(new FileInputStream(file));
-                Utils.copy(infoStream, NullOutputStream.NULL_OUTPUT_STREAM);
+                Utils.copy(infoStream, NullOutputStream.INSTANCE);
                 infoStream.close();
 
                 // fix line endings for shell scripts
@@ -142,7 +143,7 @@ class ControlBuilder {
                     in = new ByteArrayInputStream(buf);
                 }
 
-                addControlEntry(file.getName(), IOUtils.toString(in), outputStream);
+                addControlEntry(file.getName(), IOUtils.toString(in,StandardCharsets.UTF_8), outputStream);
 
                 in.close();
             }

--- a/src/main/java/org/vafer/jdeb/DebMaker.java
+++ b/src/main/java/org/vafer/jdeb/DebMaker.java
@@ -216,7 +216,7 @@ public class DebMaker {
     }
 
     public void setSignDigest(String digest) {
-        this.signDigest = signDigest;
+        this.signDigest = digest;
     }
 
 

--- a/src/main/java/org/vafer/jdeb/mapping/LsMapper.java
+++ b/src/main/java/org/vafer/jdeb/mapping/LsMapper.java
@@ -112,12 +112,12 @@ drwxr-xr-x    4 tcurdt  tcurdt   136 Jun 25 03:48 classes
     }
 
 
-    private int convertModeFromString( final String mode ) {
-
-        final char[] m = mode.toCharArray();
+    private int convertModeFromString(final String mode) {
+        // Define the position values for each permission bit
+        final int[] positions = { 0400, 0200, 0100, 0040, 0020, 0010, 0004, 0002, 0001 };
         /*
            -rwxrwxrwx
-
+    
            4000    set-user-ID-on-execution bit
            2000    set-user-ID-on-execution bit
            1000    sticky bit
@@ -131,15 +131,18 @@ drwxr-xr-x    4 tcurdt  tcurdt   136 Jun 25 03:48 classes
            0002    allow write by others.
            0001    execute / search
          */
-        // TODO: simplified - needs fixing
+        // TODO: Simplified - needs fixing
         int sum = 0;
-        int bit = 1;
-        for (int i = m.length - 1; i >= 0; i--) {
-            if (m[i] != '-') {
-                sum += bit;
+    
+        // Iterate over each character in the mode string
+        for (int i = 0; i < mode.length(); i++) {
+            // If the character represents a permission bit (r, w, x, or -)
+            if (mode.charAt(i) != '-') {
+                // Add the corresponding position value to the sum
+                sum += positions[i];
             }
-            bit += bit;
         }
+    
         return sum;
     }
 

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -461,9 +461,16 @@ public class DebMojo extends AbstractMojo {
     /**
      * @return whether or not Maven is currently operating in the execution root
      */
+    
+    // whether the current Maven project is a submodule or not
+    //checksif the project directory is different from the Maven execution root directory
     private boolean isSubmodule() {
         // FIXME there must be a better way
-        return !session.getExecutionRootDirectory().equalsIgnoreCase(baseDir.toString());
+        // return !session.getExecutionRootDirectory().equalsIgnoreCase(baseDir.toString());
+        if (project.getParent() != null) {
+            return true; // if the project has a parent, it is likely a submodule
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/vafer/jdeb/producers/DataProducerArchive.java
+++ b/src/main/java/org/vafer/jdeb/producers/DataProducerArchive.java
@@ -90,11 +90,17 @@ public final class DataProducerArchive extends AbstractDataProducer implements D
                     final TarArchiveEntry dst = new TarArchiveEntry(src.getName(), true);
                     //TODO: if (src.isUnixSymlink()) {
                     //}
-
-                    dst.setSize(src.getSize());
-                    dst.setMode(src.getUnixMode());
-                    dst.setModTime(src.getTime());
-
+                    //check if the entry name ends with a symbolic link extension (.symlink)
+                    if (src.getName().endsWith(".symlink")) {
+                        // symbolic link target from the entry name
+                        String symlinkTarget = src.getName().substring(0, src.getName().length() - ".symlink".length());
+                        dst.setMode(TarArchiveEntry.LF_SYMLINK); // set the entry type to symbolic link
+                        dst.setLinkName(symlinkTarget); // set the symbolic link target
+                    }else{
+                        dst.setSize(src.getSize());
+                        dst.setMode(src.getUnixMode());
+                        dst.setModTime(src.getTime());
+                    }
                     return dst;
                 }
             };


### PR DESCRIPTION
adding properties for the source and target 1.8 to 17 resolved the warning

import java.nio.charset.StandardCharsets; in ControlBuilder

few of the TODO's and FIXNeeded parts

NullOutputStream.NULL_OUTPUT_STREAM is deprecated changed to NullOutputStream.INSTANCE

because NullOutputStream have a field named INSTANCE, resolved the warning. in ChangesFileBuilder and ControlBuilder

String content = IOUtils.toString(in); changed to String content = IOUtils.toString(in, StandardCharsets.UTF_8); in ControlBuilder

this.signDigest = signDigest; changed to this.signDigest = digest;

changes to LsMapper private int convertModeFromString( final String mode )

changes in isSubmodules(), whether the current Maven project is a submodule or not

check if the entry name ends with a symbolic link extension (.symlink) i.e., if (src.getName().endsWith(".symlink"))