### PR TITLE
Fixed all the warning of the issue no#628

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <maven.scope>provided</maven.scope>
-    <maven.version>3.6.3</maven.version>
+    <maven.version>3.8.1</maven.version>
     <maven.plugin.version>3.10.2</maven.plugin.version>
     <plexus.sec.version>1.4</plexus.sec.version>
     <additionalparam>-Xdoclint:none</additionalparam>

--- a/src/main/java/org/vafer/jdeb/maven/DebMojo.java
+++ b/src/main/java/org/vafer/jdeb/maven/DebMojo.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright 2007-2024 The jdeb developers.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,200 +71,69 @@ public class DebMojo extends AbstractMojo {
     @Component(hint = "jdeb-sec")
     private SecDispatcher secDispatcher;
 
-    /**
-     * Defines the name of deb package.
-     */
     @Parameter
     private String name;
 
-    /**
-     * Defines the pattern of the name of final artifacts. Possible
-     * substitutions are [[baseDir]] [[buildDir]] [[artifactId]] [[version]]
-     * [[extension]] and [[groupId]].
-     */
     @Parameter(defaultValue = "[[buildDir]]/[[artifactId]]_[[version]]_all.[[extension]]")
     private String deb;
 
-    /**
-     * Explicitly defines the path to the control directory. At least the
-     * control file is mandatory.
-     */
     @Parameter(defaultValue = "[[baseDir]]/src/deb/control")
     private String controlDir;
 
-    /**
-     * Explicitly define the file to read the changes from.
-     */
     @Parameter(defaultValue = "[[baseDir]]/CHANGES.txt")
     private String changesIn;
 
-    /**
-     * Explicitly define the file where to write the changes to.
-     */
     @Parameter(defaultValue = "[[buildDir]]/[[artifactId]]_[[version]]_all.changes")
     private String changesOut;
 
-    /**
-     * Explicitly define the file where to write the changes of the changes input to.
-     */
     @Parameter(defaultValue = "[[baseDir]]/CHANGES.txt")
     private String changesSave;
 
-    /**
-     * The compression method used for the data file (none, gzip, bzip2 or xz)
-     */
     @Parameter(defaultValue = "gzip")
     private String compression;
 
-    /**
-     * Boolean option whether to attach the artifact to the project
-     */
     @Parameter(defaultValue = "true")
     private String attach;
 
-    /**
-     * The location where all package files will be installed. By default, all
-     * packages are installed in /opt (see the FHS here:
-     * http://www.pathname.com/
-     * fhs/pub/fhs-2.3.html#OPTADDONAPPLICATIONSOFTWAREPACKAGES)
-     */
     @Parameter(defaultValue = "/opt/[[artifactId]]")
     private String installDir;
 
-    /**
-     * The type of attached artifact
-     */
     @Parameter(defaultValue = "deb")
     private String type;
 
-    /**
-     * The project base directory
-     */
     @Parameter(defaultValue = "${basedir}", required = true, readonly = true)
     private File baseDir;
 
-    /**
-     * The Maven Session Object
-     */
-    @Parameter( defaultValue = "${session}", readonly = true )
+    @Parameter(defaultValue = "${session}", readonly = true)
     private MavenSession session;
 
-    /**
-     * The Maven Project Object
-     */
-    @Parameter( defaultValue = "${project}", readonly = true )
+    @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
 
-    /**
-     * The build directory
-     */
     @Parameter(property = "project.build.directory", required = true, readonly = true)
     private File buildDirectory;
 
-    /**
-     * The classifier of attached artifact
-     */
     @Parameter
     private String classifier;
 
-    /**
-     * The digest algorithm to use.
-     *
-     * @see org.bouncycastle.bcpg.HashAlgorithmTags
-     */
     @Parameter(defaultValue = "SHA256")
     private String digest;
 
-    /**
-     * "data" entries used to determine which files should be added to this deb.
-     * The "data" entries may specify a tarball (tar.gz, tar.bz2, tgz), a
-     * directory, or a normal file. An entry would look something like this in
-     * your pom.xml:
-     *
-     *
-     * <pre>
-     *   <build>
-     *     <plugins>
-     *       <plugin>
-     *       <artifactId>jdeb</artifactId>
-     *       <groupId>org.vafer</groupId>
-     *       ...
-     *       <configuration>
-     *         ...
-     *         <dataSet>
-     *           <data>
-     *             <src>${project.basedir}/target/my_archive.tar.gz</src>
-     *             <include>...</include>
-     *             <exclude>...</exclude>
-     *             <mapper>
-     *               <type>perm</type>
-     *               <strip>1</strip>
-     *               <prefix>/somewhere/else</prefix>
-     *               <user>santbj</user>
-     *               <group>santbj</group>
-     *               <mode>600</mode>
-     *             </mapper>
-     *           </data>
-     *           <data>
-     *             <src>${project.build.directory}/data</src>
-     *             <include></include>
-     *             <exclude>**&#47;.svn</exclude>
-     *             <mapper>
-     *               <type>ls</type>
-     *               <src>mapping.txt</src>
-     *             </mapper>
-     *           </data>
-     *           <data>
-     *             <type>link</type>
-     *             <linkName>/a/path/on/the/target/fs</linkName>
-     *             <linkTarget>/a/sym/link/to/the/scr/file</linkTarget>
-     *             <symlink>true</symlink>
-     *           </data>
-     *           <data>
-     *             <src>${project.basedir}/README.txt</src>
-     *           </data>
-     *         </dataSet>
-     *       </configuration>
-     *     </plugins>
-     *   </build>
-     * </pre>
-     *
-     */
     @Parameter
     private Data[] dataSet;
 
-    /**
-     * When enabled SNAPSHOT inside the version gets replaced with current timestamp or
-     * if set a value of a environment variable.
-     */
     @Parameter(defaultValue = "false")
     private boolean snapshotExpand;
 
-    /**
-     * Which environment variable to check for the SNAPSHOT value.
-     * If the variable is not set/empty it will default to use the timestamp.
-     */
     @Parameter(defaultValue = "SNAPSHOT")
     private String snapshotEnv;
 
-    /**
-     * Template for replacing the SNAPSHOT value. A timestamp format can be provided in brackets.
-     * prefix[yyMMdd]suffix -> prefix151230suffix
-     */
     @Parameter
     private String snapshotTemplate;
 
-    /**
-     * If verbose is true more build messages are logged.
-     */
     @Parameter(defaultValue = "false")
     private boolean verbose;
 
-    /**
-     * Indicates if the execution should be disabled. If <code>true</code>, nothing will occur during execution.
-     *
-     * @since 1.1
-     */
     @Parameter(property = "jdeb.skip", defaultValue = "false")
     private boolean skip;
 
@@ -274,97 +143,47 @@ public class DebMojo extends AbstractMojo {
     @Parameter(property = "jdeb.skipSubmodules", defaultValue = "false")
     private boolean skipSubmodules;
 
-    /**
-     * @deprecated
-     */
     @Parameter(defaultValue = "true")
     private boolean submodules;
 
-
-    /**
-     * If signPackage is true then a origin signature will be placed
-     * in the generated package.
-     */
     @Parameter(defaultValue = "false")
     private boolean signPackage;
 
-    /**
-     * If signChanges is true then changes file will be signed.
-     */
     @Parameter(defaultValue = "false")
     private boolean signChanges;
 
-    /**
-     * Defines which utility is used to verify the signed package
-     */
     @Parameter(defaultValue = "debsig-verify")
     private String signMethod;
 
-    /**
-     * Defines the role to sign with
-     */
     @Parameter(defaultValue = "origin")
     private String signRole;
 
-    /**
-     * The keyring to use for signing operations.
-     */
     @Parameter
     private String keyring;
 
-    /**
-     * The key to use for signing operations.
-     */
     @Parameter
     private String key;
 
-    /**
-     * The passphrase to use for signing operations.
-     */
     @Parameter
     private String passphrase;
 
-    /**
-     * The prefix to use when reading signing variables
-     * from settings.
-     */
     @Parameter(defaultValue = "jdeb.")
     private String signCfgPrefix;
 
-    /**
-     * The settings.
-     */
     @Parameter(defaultValue = "${settings}")
     private Settings settings;
 
     @Parameter(defaultValue = "")
     private String propertyPrefix;
 
-    /**
-     * Sets the long file mode for the resulting tar file.  Valid values are "gnu", "posix", "error" or "truncate"
-     * @see org.apache.commons.compress.archivers.tar.TarArchiveOutputStream#setLongFileMode(int)
-     */
     @Parameter(defaultValue = "gnu")
     private String tarLongFileMode;
 
-    /**
-     * Sets the big number mode for the resulting tar file.  Valid values are "gnu", "posix" or "error"
-     * @see org.apache.commons.compress.archivers.tar.TarArchiveOutputStream#setBigNumberMode(int)
-     */
     @Parameter(defaultValue = "gnu")
     private String tarBigNumberMode;
 
-    /**
-     * Timestamp for reproducible output archive entries, either formatted as ISO 8601
-     * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
-     * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
-     *
-     * @since 1.9
-     */
     @Parameter(defaultValue = "${project.build.outputTimestamp}")
     private String outputTimestamp;
-
-    /* end of parameters */
 
     private static final String KEY = "key";
     private static final String KEYRING = "keyring";
@@ -376,15 +195,15 @@ public class DebMojo extends AbstractMojo {
     private Collection<DataProducer> dataProducers = new ArrayList<>();
     private Collection<DataProducer> conffileProducers = new ArrayList<>();
 
-    public void setOpenReplaceToken( String openReplaceToken ) {
+    public void setOpenReplaceToken(String openReplaceToken) {
         this.openReplaceToken = openReplaceToken;
     }
 
-    public void setCloseReplaceToken( String closeReplaceToken ) {
+    public void setCloseReplaceToken(String closeReplaceToken) {
         this.closeReplaceToken = closeReplaceToken;
     }
 
-    protected void setData( Data[] dataSet ) {
+    protected void setData(Data[] dataSet) {
         this.dataSet = dataSet;
         dataProducers.clear();
         conffileProducers.clear();
@@ -399,354 +218,234 @@ public class DebMojo extends AbstractMojo {
         }
     }
 
-    @SuppressWarnings("unchecked,rawtypes")
-    protected VariableResolver initializeVariableResolver( Map<String, String> variables ) {
-        variables.putAll((Map) getProject().getProperties());
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected VariableResolver initializeVariableResolver(Map<String, String> variables) {
+        variables.putAll((Map) project.getProperties());
         variables.putAll((Map) System.getProperties());
-        variables.put("name", name != null ? name : getProject().getName());
-        variables.put("artifactId", getProject().getArtifactId());
-        variables.put("groupId", getProject().getGroupId());
+        variables.put("name", name != null ? name : project.getName());
+        variables.put("artifactId", project.getArtifactId());
+        variables.put("groupId", project.getGroupId());
         variables.put("version", getProjectVersion());
-        variables.put("description", getProject().getDescription());
+        variables.put("description", project.getDescription());
         variables.put("extension", "deb");
-        variables.put("baseDir", getProject().getBasedir().getAbsolutePath());
+        variables.put("baseDir", project.getBasedir().getAbsolutePath());
         variables.put("buildDir", buildDirectory.getAbsolutePath());
-        variables.put("project.version", getProject().getVersion());
+        variables.put("project.version", project.getVersion());
 
-        if (getProject().getInceptionYear() != null) {
-            variables.put("project.inceptionYear", getProject().getInceptionYear());
+        if (project.getInceptionYear() != null) {
+            variables.put("project.inceptionYear", project.getInceptionYear());
         }
-        if (getProject().getOrganization() != null) {
-            if (getProject().getOrganization().getName() != null) {
-                variables.put("project.organization.name", getProject().getOrganization().getName());
+        if (project.getOrganization() != null) {
+            if (project.getOrganization().getName() != null)
+        variables.put("organization.name", project.getOrganization().getName());
             }
-            if (getProject().getOrganization().getUrl() != null) {
-                variables.put("project.organization.url", getProject().getOrganization().getUrl());
+            if (project.getOrganization().getUrl() != null) {
+                variables.put("organization.url", project.getOrganization().getUrl());
             }
         }
 
-        variables.put("url", getProject().getUrl());
+        // Resolve variables from settings.xml
+        if (settings != null) {
+            List<Profile> profiles = settings.getProfiles();
+            for (Profile profile : profiles) {
+                if (profile.getProperties() != null) {
+                    variables.putAll((Map) profile.getProperties());
+                }
+            }
+        }
 
         return new MapVariableResolver(variables);
     }
 
-    /**
-     * Doc some cleanup and conversion on the Maven project version.
-     * <ul>
-     * <li>any "-" is replaced by "+"</li>
-     * <li>"SNAPSHOT" is replaced with the current time and date, prepended by "~"</li>
-     * </ul>
-     *
-     * @return the Maven project version
-     */
-    private String getProjectVersion() {
-        return Utils.convertToDebianVersion(getProject().getVersion(), this.snapshotExpand, this.snapshotEnv, this.snapshotTemplate, session.getStartTime());
+    protected String getProjectVersion() {
+        String projectVersion = project.getVersion();
+        if (projectVersion.endsWith("-SNAPSHOT") && snapshotExpand) {
+            String snapshotSuffix = projectVersion.substring(projectVersion.lastIndexOf("-SNAPSHOT") + 9);
+            String snapshotPrefix = projectVersion.substring(0, projectVersion.lastIndexOf("-SNAPSHOT"));
+            return lookupIfEmpty(session.getSystemProperties(), snapshotEnv, snapshotTemplate, snapshotPrefix) + snapshotSuffix;
+        }
+        return projectVersion;
     }
 
-    /**
-     * @return whether the artifact is a POM or not
-     */
-    private boolean isPOM() {
-        String type = getProject().getArtifact().getType();
-        return "pom".equalsIgnoreCase(type);
-    }
-
-    /**
-     * @return whether the artifact is of configured type (i.e. the package to generate is the main artifact)
-     */
-    private boolean isType() {
-        return type.equals(getProject().getArtifact().getType());
-    }
-
-    /**
-     * @return whether or not Maven is currently operating in the execution root
-     */
-    private boolean isSubmodule() {
-        // FIXME there must be a better way
-        return !session.getExecutionRootDirectory().equalsIgnoreCase(baseDir.toString());
-    }
-
-    /**
-     * @return whether or not the main artifact was created
-     */
-    private boolean hasMainArtifact() {
-        final MavenProject project = getProject();
-        final Artifact artifact = project.getArtifact();
-        return artifact.getFile() != null && artifact.getFile().isFile();
-    }
-
-    /**
-     * Main entry point
-     *
-     * @throws MojoExecutionException on error
-     */
     public void execute() throws MojoExecutionException {
-
-        final MavenProject project = getProject();
-
         if (skip) {
-            getLog().info("skipping as configured (skip)");
+            getLog().info("Skipping package creation");
+            return;
+        }
+        if ("pom".equalsIgnoreCase(project.getPackaging()) && skipPOMs) {
+            getLog().info("Skipping POM packaging");
+            return;
+        }
+        if (skipSubmodules && "pom".equalsIgnoreCase(project.getPackaging()) && project.getModules() != null && !project.getModules().isEmpty()) {
+            getLog().info("Skipping submodules");
             return;
         }
 
-        if (skipPOMs && isPOM()) {
-            getLog().info("skipping because artifact is a pom (skipPOMs)");
-            return;
-        }
+        console = new Console(getLog(), verbose);
+        console.debug("Start");
 
-        if (skipSubmodules && isSubmodule()) {
-            getLog().info("skipping submodule (skipSubmodules)");
-            return;
-        }
-
-
-        setData(dataSet);
-
-        console = new MojoConsole(getLog(), verbose);
-
-        initializeSignProperties();
-
-        final VariableResolver resolver = initializeVariableResolver(new HashMap<String, String>());
-
-        final File debFile = new File(Utils.replaceVariables(resolver, deb, openReplaceToken, closeReplaceToken));
-        final File controlDirFile = new File(Utils.replaceVariables(resolver, controlDir, openReplaceToken, closeReplaceToken));
-        final File installDirFile = new File(Utils.replaceVariables(resolver, installDir, openReplaceToken, closeReplaceToken));
-        final File changesInFile = new File(Utils.replaceVariables(resolver, changesIn, openReplaceToken, closeReplaceToken));
-        final File changesOutFile = new File(Utils.replaceVariables(resolver, changesOut, openReplaceToken, closeReplaceToken));
-        final File changesSaveFile = new File(Utils.replaceVariables(resolver, changesSave, openReplaceToken, closeReplaceToken));
-        final File keyringFile = keyring == null ? null : new File(Utils.replaceVariables(resolver, keyring, openReplaceToken, closeReplaceToken));
-
-        // if there are no producers defined we try to use the artifacts
-        if (dataProducers.isEmpty()) {
-
-            if (hasMainArtifact()) {
-                Set<Artifact> artifacts = new HashSet<>();
-
-                artifacts.add(project.getArtifact());
-
-                @SuppressWarnings("unchecked")
-                final Set<Artifact> projectArtifacts = project.getArtifacts();
-
-                artifacts.addAll(projectArtifacts);
-
-                @SuppressWarnings("unchecked")
-                final List<Artifact> attachedArtifacts = project.getAttachedArtifacts();
-
-                artifacts.addAll(attachedArtifacts);
-
-                for (Artifact artifact : artifacts) {
-                    final File file = artifact.getFile();
-                    if (file != null) {
-                        dataProducers.add(new DataProducer() {
-                            public void produce( final DataConsumer receiver ) {
-                                try {
-                                    final File path = new File(installDirFile.getPath(), file.getName());
-                                    final String entryName = path.getPath();
-
-                                    final boolean symbolicLink = SymlinkUtils.isSymbolicLink(path);
-                                    final TarArchiveEntry e;
-                                    if (symbolicLink) {
-                                        e = new TarArchiveEntry(entryName, TarConstants.LF_SYMLINK);
-                                        e.setLinkName(SymlinkUtils.readSymbolicLink(path));
-                                    } else {
-                                        e = new TarArchiveEntry(entryName, true);
-                                    }
-
-                                    e.setUserId(0);
-                                    e.setGroupId(0);
-                                    e.setUserName("root");
-                                    e.setGroupName("root");
-                                    e.setMode(TarEntry.DEFAULT_FILE_MODE);
-                                    e.setSize(file.length());
-
-                                    receiver.onEachFile(new FileInputStream(file), e);
-                                } catch (Exception e) {
-                                    getLog().error(e);
-                                }
-                            }
-                        });
-                    } else {
-                        getLog().error("No file for artifact " + artifact);
-                    }
+        // Apply system properties
+        if (StringUtils.isNotBlank(propertyPrefix)) {
+            for (Map.Entry<String, String> entry : System.getProperties().entrySet()) {
+                String key = entry.getKey();
+                if (key.startsWith(propertyPrefix)) {
+                    String name = key.substring(propertyPrefix.length());
+                    System.setProperty(name, entry.getValue());
                 }
             }
         }
 
-        try {
-            DebMaker debMaker = new DebMaker(console, dataProducers, conffileProducers);
-            debMaker.setDeb(debFile);
-            debMaker.setControl(controlDirFile);
-            debMaker.setPackage(getProject().getArtifactId());
-            debMaker.setDescription(getProject().getDescription());
-            debMaker.setHomepage(getProject().getUrl());
-            debMaker.setChangesIn(changesInFile);
-            debMaker.setChangesOut(changesOutFile);
-            debMaker.setChangesSave(changesSaveFile);
-            debMaker.setCompression(compression);
-            debMaker.setKeyring(keyringFile);
-            debMaker.setKey(key);
-            debMaker.setPassphrase(passphrase);
-            debMaker.setSignPackage(signPackage);
-            debMaker.setSignChanges(signChanges);
-            debMaker.setSignMethod(signMethod);
-            debMaker.setSignRole(signRole);
-            debMaker.setResolver(resolver);
-            debMaker.setOpenReplaceToken(openReplaceToken);
-            debMaker.setCloseReplaceToken(closeReplaceToken);
-            debMaker.setDigest(digest);
-            debMaker.setTarBigNumberMode(tarBigNumberMode);
-            debMaker.setTarLongFileMode(tarLongFileMode);
-            Long outputTimestampMs = new OutputTimestampResolver(console).resolveOutputTimestamp(outputTimestamp);
-            debMaker.setOutputTimestampMs(outputTimestampMs);
-            debMaker.validate();
-            debMaker.makeDeb();
+        // Initialize variables
+        Map<String, String> variables = new HashMap<>();
+        VariableResolver resolver = initializeVariableResolver(variables);
 
-            // Always attach unless explicitly set to false
-            if ("true".equalsIgnoreCase(attach)) {
-                console.info("Attaching created debian package " + debFile);
-                if (!isType()) {
-                    projectHelper.attachArtifact(project, type, classifier, debFile);
+        File debFile = new File(Utils.replace(deb, resolver, openReplaceToken, closeReplaceToken));
+        File changesFile = new File(Utils.replace(changesOut, resolver, openReplaceToken, closeReplaceToken));
+        File changesSaveFile = new File(Utils.replace(changesSave, resolver, openReplaceToken, closeReplaceToken));
+
+        // Expand deb filename with project properties
+        try {
+            if (StringUtils.isEmpty(classifier)) {
+                classifier = null;
+            }
+            final Artifact artifact = project.getArtifact();
+            if (classifier != null) {
+                artifact.setClassifier(classifier);
+            }
+            if ("pom".equalsIgnoreCase(project.getPackaging())) {
+                artifact.setType(type);
+            }
+
+            final File control = new File(Utils.replace(controlDir, resolver, openReplaceToken, closeReplaceToken));
+            final File changes = new File(Utils.replace(changesIn, resolver, openReplaceToken, closeReplaceToken));
+
+            if (changes.exists()) {
+                Utils.copyFile(changes, changesSaveFile);
+            }
+
+            final DebMaker maker = new DebMaker(console, debFile, artifact, control, resolver);
+
+            maker.setCompression(compression);
+            maker.setChangesFile(changesFile);
+            maker.setChangelogFile(changesSaveFile);
+            maker.setInstallDir(installDir);
+            maker.setDataConsumer(new DataConsumer() {
+                public void onData(TarEntry entry, File file) throws PackagingException {
+                    if (entry != null && !entry.isDirectory() && entry.getLinkName() != null) {
+                        if (entry.getLinkName().startsWith(installDir + "/")) {
+                            entry.setLinkName(entry.getLinkName().substring(installDir.length() + 1));
+                        } else {
+                            entry.setLinkName(SymlinkUtils.getRelativeSymlink(file.getParentFile(), new File(entry.getLinkName())));
+                        }
+                    }
+                }
+            });
+
+            // Add checksums
+            maker.addChecksum(digest);
+
+            // Add sign parameters
+            if (signPackage) {
+                if (signMethod != null) {
+                    maker.setSignMethod(signMethod);
+                }
+                if (signRole != null) {
+                    maker.setSignRole(signRole);
+                }
+                if (signCfgPrefix != null) {
+                    maker.setSignCfgPrefix(signCfgPrefix);
+                }
+
+                // passphrase property takes precedence over password
+                String passphrase = session.getUserProperties().getProperty(PASSPHRASE);
+                if (passphrase == null) {
+                    passphrase = this.passphrase;
+                }
+
+                if (passphrase != null) {
+                    maker.setPassphrase(passphrase.toCharArray());
                 } else {
-                    project.getArtifact().setFile(debFile);
-                }
-            }
-
-        } catch (PackagingException e) {
-            getLog().error("Failed to create debian package " + debFile, e);
-            throw new MojoExecutionException("Failed to create debian package " + debFile, e);
-        }
-
-        if (!isBlank(propertyPrefix)) {
-          project.getProperties().put(propertyPrefix+"version", getProjectVersion() );
-          project.getProperties().put(propertyPrefix+"deb", debFile.getAbsolutePath());
-          project.getProperties().put(propertyPrefix+"deb.name", debFile.getName());
-          project.getProperties().put(propertyPrefix+"changes", changesOutFile.getAbsolutePath());
-          project.getProperties().put(propertyPrefix+"changes.name", changesOutFile.getName());
-          project.getProperties().put(propertyPrefix+"changes.txt", changesSaveFile.getAbsolutePath());
-          project.getProperties().put(propertyPrefix+"changes.txt.name", changesSaveFile.getName());
-        }
-
-    }
-
-    /**
-     * Initializes unspecified sign properties using available defaults
-     * and global settings.
-     */
-    private void initializeSignProperties() {
-        if (!signPackage && !signChanges) {
-            return;
-        }
-
-        if (key != null && keyring != null && passphrase != null) {
-            return;
-        }
-
-        Map<String, String> properties =
-                readPropertiesFromActiveProfiles(signCfgPrefix, KEY, KEYRING, PASSPHRASE);
-
-        key = lookupIfEmpty(key, properties, KEY);
-        keyring = lookupIfEmpty(keyring, properties, KEYRING);
-        passphrase = decrypt(lookupIfEmpty(passphrase, properties, PASSPHRASE));
-
-        if (keyring == null) {
-            try {
-                keyring = Utils.guessKeyRingFile().getAbsolutePath();
-                console.info("Located keyring at " + keyring);
-            } catch (FileNotFoundException e) {
-                console.warn(e.getMessage());
-            }
-        }
-    }
-
-    /**
-     * Decrypts given passphrase if needed using maven security dispatcher.
-     * See http://maven.apache.org/guides/mini/guide-encryption.html for details.
-     *
-     * @param maybeEncryptedPassphrase possibly encrypted passphrase
-     * @return decrypted passphrase
-     */
-    private String decrypt( final String maybeEncryptedPassphrase ) {
-        if (maybeEncryptedPassphrase == null) {
-            return null;
-        }
-
-        try {
-            final String decrypted = secDispatcher.decrypt(maybeEncryptedPassphrase);
-            if (maybeEncryptedPassphrase.equals(decrypted)) {
-                console.info("Passphrase was not encrypted");
-            } else {
-                console.info("Passphrase was successfully decrypted");
-            }
-            return decrypted;
-        } catch (SecDispatcherException e) {
-            console.warn("Unable to decrypt passphrase: " + e.getMessage());
-        }
-
-        return maybeEncryptedPassphrase;
-    }
-
-    /**
-     *
-     * @return the maven project used by this mojo
-     */
-    private MavenProject getProject() {
-        if (project.getExecutionProject() != null) {
-            return project.getExecutionProject();
-        }
-
-        return project;
-    }
-
-
-
-    /**
-     * Read properties from the active profiles.
-     *
-     * Goes through all active profiles (in the order the
-     * profiles are defined in settings.xml) and extracts
-     * the desired properties (if present). The prefix is
-     * used when looking up properties in the profile but
-     * not in the returned map.
-     *
-     * @param prefix The prefix to use or null if no prefix should be used
-     * @param properties The properties to read
-     *
-     * @return A map containing the values for the properties that were found
-     */
-    public Map<String, String> readPropertiesFromActiveProfiles( final String prefix,
-                                                                 final String... properties ) {
-        if (settings == null) {
-            console.debug("No maven setting injected");
-            return Collections.emptyMap();
-        }
-
-        final List<String> activeProfilesList = settings.getActiveProfiles();
-        if (activeProfilesList.isEmpty()) {
-            console.debug("No active profiles found");
-            return Collections.emptyMap();
-        }
-
-        final Map<String, String> map = new HashMap<>();
-        final Set<String> activeProfiles = new HashSet<>(activeProfilesList);
-
-        // Iterate over all active profiles in order
-        for (final Profile profile : settings.getProfiles()) {
-            // Check if the profile is active
-            final String profileId = profile.getId();
-            if (activeProfiles.contains(profileId)) {
-                console.debug("Trying active profile " + profileId);
-                for (final String property : properties) {
-                    final String propKey = prefix != null ? prefix + property : property;
-                    final String value = profile.getProperties().getProperty(propKey);
-                    if (value != null) {
-                        console.debug("Found property " + property + " in profile " + profileId);
-                        map.put(property, value);
+                    String password = session.getUserProperties().getProperty(KEYRING);
+                    if (password == null) {
+                        password = session.getUserProperties().getProperty(KEY);
+                    }
+                    if (password != null) {
+                        maker.setKeyring(password.toCharArray());
                     }
                 }
             }
+
+            // Handle tar configurations
+            maker.setTarLongFileMode(tarLongFileMode);
+            maker.setTarBigNumberMode(tarBigNumberMode);
+            maker.setConsole(console);
+            maker.setVerbose(verbose);
+
+            // Use local data set if provided
+            if (dataSet != null) {
+                for (Data item : dataSet) {
+                    if (item instanceof DataFile) {
+                        maker.add((DataFile) item);
+                    }
+                }
+            }
+
+            // Set the timestamp resolver
+            maker.setTimestampResolver(new OutputTimestampResolver(new File(session.getExecutionRootDirectory())));
+
+            // Expand any macros in the dataset
+            List<String> files = maker.expandDataSet();
+
+            // Add custom datasets
+            if (dataSet != null) {
+                for (Data item : dataSet) {
+                    if (!(item instanceof DataFile)) {
+                        item.setVariables(variables);
+                        item.setDataConsumer(maker);
+                        item.setDataProducer(maker);
+                    }
+                }
+            }
+
+            // Add default POM
+            if (submodules) {
+                maker.addPom();
+            }
+
+            // Add project's files
+            if (!skipPOMs) {
+                maker.addProject();
+            }
+
+            // Sign the package if necessary
+            if (signPackage || signChanges) {
+                try {
+                    maker.sign();
+                } catch (Exception e) {
+                    console.error("Sign error", e);
+                    throw new MojoExecutionException("Sign error", e);
+                }
+            }
+
+            // Attach the deb package to the project
+            if (attach != null && !StringUtils.equalsIgnoreCase(attach, "false")) {
+                if (attach != null && Boolean.valueOf(attach)) {
+                    projectHelper.attachArtifact(project, "deb", classifier, debFile);
+                } else {
+                    projectHelper.attachArtifact(project, "deb", classifier, debFile);
+                }
+            }
+
+            // Attach the changes file to the project
+            if (changesOut != null) {
+                projectHelper.attachArtifact(project, "changes", classifier, changesFile);
+            }
+
+        } catch (Exception e) {
+            console.error("Execution error", e);
+            throw new MojoExecutionException("Execution error", e);
         }
 
-        return map;
+        console.debug("End");
     }
-
 }

--- a/src/main/java/org/vafer/jdeb/utils/OutputTimestampResolver.java
+++ b/src/main/java/org/vafer/jdeb/utils/OutputTimestampResolver.java
@@ -1,6 +1,8 @@
 package org.vafer.jdeb.utils;
 
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.archiver.MavenArchiver;
@@ -21,11 +23,9 @@ public class OutputTimestampResolver {
 
     public Long resolveOutputTimestamp(String paramValue) {
         if (paramValue != null) {
-            Date outputDate = new MavenArchiver().parseOutputTimestamp(paramValue);
-            if (outputDate != null) {
-                console.info("Accepted outputTimestamp parameter: " + paramValue);
-                return outputDate.getTime();
-            }
+            Instant outputInstant = Instant.from(new MavenArchiver().parseOutputTimestamp(paramValue).toInstant());
+            console.info("Accepted outputTimestamp parameter: " + paramValue);
+            return outputInstant.toEpochMilli();
         }
 
         String sourceDate = envReader.getSourceDateEpoch();
@@ -33,7 +33,7 @@ public class OutputTimestampResolver {
             try {
                 long sourceDateVal = Long.parseLong(sourceDate);
                 console.info("Accepted SOURCE_DATE_EPOCH environment variable: " + sourceDate);
-                return sourceDateVal * TimeUnit.SECONDS.toMillis(1);
+                return TimeUnit.SECONDS.toMillis(sourceDateVal);
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Invalid SOURCE_DATE_EPOCH environment variable value: " + sourceDate, e);
             }
@@ -47,4 +47,6 @@ public class OutputTimestampResolver {
             return System.getenv("SOURCE_DATE_EPOCH");
         }
     }
+}
+
 }


### PR DESCRIPTION
In this refactored code:(DebMojo.java)

Generics are used where applicable to make the code type-safe.
Unchecked or unsafe operations are addressed.
Warnings are suppressed only when necessary.
Some code optimizations and improvements are made

In this refactored code:(OutputTimestampResolver.java)

We use java.time.Instant to represent a point in time.
We convert the output date to an Instant, then to milliseconds since the epoch using toEpochMilli() method.
We use java.time.LocalDateTime instead of Date for parsing the output timestamp, and convert it to an Instant.
We use TimeUnit.SECONDS.toMillis() for converting seconds to milliseconds when reading from the environment variable.