### PR TITLE
Restore maven-archiver as a compile scoped dependency to fix reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,10 +122,10 @@
       <scope>${maven.scope}</scope>
     </dependency>
     <dependency>
+      <!-- maven-archiver must be compile scope, see #736 -->
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-archiver</artifactId>
       <version>3.6.2</version>
-      <scope>${maven.scope}</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>

--- a/src/it/project-build-outputTimestamp/pom.xml
+++ b/src/it/project-build-outputTimestamp/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.vafer</groupId>
+    <artifactId>jdeb-it</artifactId>
+    <version>1.0</version>
+    <description>description from pom</description>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.outputTimestamp>2024-08-26T14:00:00Z</project.build.outputTimestamp>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.vafer</groupId>
+                <artifactId>jdeb</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jdeb</goal>
+                        </goals>
+                        <configuration>
+                            <verbose>true</verbose>
+                            <controlDir>${basedir}/src/deb/control</controlDir>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/project-build-outputTimestamp/src/deb/control/control
+++ b/src/it/project-build-outputTimestamp/src/deb/control/control
@@ -1,0 +1,7 @@
+Package: [[name]]
+Version: [[version]]
+Section: misc
+Priority: low
+Architecture: all
+Description: [[description]]
+Maintainer: tcurdt@vafer.org

--- a/src/it/project-build-outputTimestamp/src/main/java/org/vafer/jdeb/examples/Main.java
+++ b/src/it/project-build-outputTimestamp/src/main/java/org/vafer/jdeb/examples/Main.java
@@ -1,0 +1,7 @@
+package org.vafer.jdeb.examples;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("jdeb example!");
+    }    
+}

--- a/src/it/project-build-outputTimestamp/verify.groovy
+++ b/src/it/project-build-outputTimestamp/verify.groovy
@@ -1,0 +1,1 @@
+assert new File( basedir, 'target/jdeb-it_1.0_all.deb' ).exists();

--- a/src/main/java/org/vafer/jdeb/utils/OutputTimestampResolver.java
+++ b/src/main/java/org/vafer/jdeb/utils/OutputTimestampResolver.java
@@ -1,6 +1,7 @@
 package org.vafer.jdeb.utils;
 
-import java.util.Date;
+import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.archiver.MavenArchiver;
@@ -21,10 +22,10 @@ public class OutputTimestampResolver {
 
     public Long resolveOutputTimestamp(String paramValue) {
         if (paramValue != null) {
-            Date outputDate = new MavenArchiver().parseOutputTimestamp(paramValue);
-            if (outputDate != null) {
+            Optional<Instant> outputDate = MavenArchiver.parseBuildOutputTimestamp(paramValue);
+            if (outputDate.isPresent()) {
                 console.info("Accepted outputTimestamp parameter: " + paramValue);
-                return outputDate.getTime();
+                return outputDate.get().toEpochMilli();
             }
         }
 


### PR DESCRIPTION
Restore maven-archiver as a compile scoped dependency to fix reproducible builds (#736)

Additionally use non-deprecated MavenArchiver.parseBuildOutputTimestamp() method